### PR TITLE
Fixed issue with running start_tray.py

### DIFF
--- a/mkchromecast/tray_threading.py
+++ b/mkchromecast/tray_threading.py
@@ -41,6 +41,7 @@ class Worker(QObject):
         try:                        # This should fix the error socket.gaierror making the system tray to be closed.
             self.cc = casting()
             self.cc.initialize_cast()
+            self.cc.availablecc()
         except socket.gaierror:
             if debug == True:
                 print(colors.warning(':::Threading::: Socket error, CC set to 0'))


### PR DESCRIPTION
availablecc() was not called and so availablecc was being interpreted as the method, not the property.

```
Traceback (most recent call last):
  File "/work/Dev/mkchromecast/mkchromecast/tray_threading.py", line 48, in _search_cast_
    if len(self.cc.availablecc) == 0 and tray == True:
TypeError: object of type 'instancemethod' has no len()
Aborted
```