### PR TITLE
Sonos support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ mkchromecast
 [![GitHub release](https://img.shields.io/github/release/muammar/mkchromecast.svg)](https://github.com/muammar/mkchromecast/releases/latest)
 
 This is a program to cast your **macOS** audio, or **Linux** audio to your
-Google Cast devices. It can also [cast video files](#video).
+Google Cast devices or Sonos speakers. It can also [cast video files](#video).
 
 It is written in Python, and it can stream via `node.js`, `parec` (**Linux**),
 `ffmpeg`, or `avconv`.  **mkchromecast** is capable of using lossy and lossless
@@ -62,6 +62,16 @@ Check these images:
 * [Awesome WM with Blue icons](https://raw.githubusercontent.com/muammar/mkchromecast/master/images/Awesome_BI.png)
 
 
+SONOS support
+--------------
+
+If you have Sonos speakers, you can play whatever you are listening in your
+computer with **mkchromecast**. To add Sonos support, install the `soco` python
+module:
+
+```
+pip install soco
+```
 
 Requirements:
 ------------
@@ -102,7 +112,8 @@ following:
 * ffmpeg (optional).
 * avconv (optional).
 * PyQt5 (optional if you want to use the system tray menu).
-* youtube-dl (option if you plan to cast youtube URLs).
+* youtube-dl (optional if you plan to cast youtube URLs).
+* soco (This module add Sonos support to mkchromecast).
 
 For those who don't like Pulseaudio, it is possible to [cast using
 ALSA](https://github.com/muammar/mkchromecast/wiki/ALSA). In that case the
@@ -124,8 +135,8 @@ requirements are:
 * ffmpeg.
 * avconv (optional).
 * PyQt5 (optional if you want to use the system tray menu).
-* youtube-dl (option if you plan to cast youtube URLs).
-
+* youtube-dl (optional if you plan to cast youtube URLs).
+* soco (This module add Sonos support to mkchromecast).
 
 
 Install
@@ -669,7 +680,6 @@ TODO
 ----
 
 * Verify all exceptions when the system tray menu fails.
-* Add SONOS support.
 
 Contribute
 ----------

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Check these images:
 * [Awesome WM with Blue icons](https://raw.githubusercontent.com/muammar/mkchromecast/master/images/Awesome_BI.png)
 
 
-SONOS support
+Sonos support
 --------------
 
 If you have Sonos speakers, you can play whatever you are listening in your
@@ -113,7 +113,7 @@ following:
 * avconv (optional).
 * PyQt5 (optional if you want to use the system tray menu).
 * youtube-dl (optional if you plan to cast youtube URLs).
-* soco (This module add Sonos support to mkchromecast).
+* soco (this module adds Sonos support to mkchromecast).
 
 For those who don't like Pulseaudio, it is possible to [cast using
 ALSA](https://github.com/muammar/mkchromecast/wiki/ALSA). In that case the
@@ -136,7 +136,7 @@ requirements are:
 * avconv (optional).
 * PyQt5 (optional if you want to use the system tray menu).
 * youtube-dl (optional if you plan to cast youtube URLs).
-* soco (This module add Sonos support to mkchromecast).
+* soco (this module adds Sonos support to mkchromecast).
 
 
 Install

--- a/README.md
+++ b/README.md
@@ -65,13 +65,23 @@ Check these images:
 Sonos support
 --------------
 
-If you have Sonos speakers, you can play whatever you are listening in your
+If you have Sonos speakers, you can play whatever you are listening to in your
 computer with **mkchromecast**. To add Sonos support, install the `soco` python
 module:
 
 ```
 pip install soco
 ```
+
+Contribute
+----------
+
+If you want to contribute, help me improving this application by [reporting
+issues](https://github.com/muammar/mkchromecast/issues), [creating pull
+requests](https://github.com/muammar/mkchromecast/pulls), or you may also buy
+me some pizza :).
+
+[![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=RZLF7TDCAXT9Q&lc=US&item_name=mkchromecast&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted)
 
 Requirements:
 ------------
@@ -657,6 +667,9 @@ Known issues
   versions of pychromecast.
 * When casting videos using the `node` backend, it is not possible to
   use neither the `--subtitle` nor the `--seek` flags.
+* When casting to Sonos the only codecs supported are: `mp3`, and `aac`.
+  I won't give `wma` support. Apparently there is a way to play `wav`, and
+  `ogg` that I will try to implement later.
 
 ##### macOS
 
@@ -681,13 +694,5 @@ TODO
 ----
 
 * Verify all exceptions when the system tray menu fails.
-
-Contribute
-----------
-
-If you want to contribute, help me improving this application by [reporting
-issues](https://github.com/muammar/mkchromecast/issues), [creating pull
-requests](https://github.com/muammar/mkchromecast/pulls), or you may also buy
-me some pizza :).
-
-[![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=RZLF7TDCAXT9Q&lc=US&item_name=mkchromecast&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHosted)
+* **Sonos**: add support to different available flags.
+* **Sonos**: add Equalizer in the controls.

--- a/README.md
+++ b/README.md
@@ -318,7 +318,8 @@ able to use all audio coding formats in **mkchromecast**, it is better to
 install `ffmpeg` with the following options enabled:
 
 ```
-brew install ffmpeg --with-fdk-aac --with-sdl2 --with-freetype --with-libass --with-libquvi --with-libvorbis --with-libvpx --with-opus --with-x265
+brew install ffmpeg --with-fdk-aac --with-tools --with-freetype --with-libass --with-libvorbis --with-libvpx --with-x265
+
 ```
 
 **mkchromecast** does not support `avconv` in **macOS**.

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@
     - Fixed a minimal problem with size of preferences pane.
     - Video support.
     - node is a supported backend for streaming video.
+    - Added Sonos speakers support.
 
 * mkchromecast (0.3.6) **released**: 2016/09/19
 

--- a/mkchromecast/audio.py
+++ b/mkchromecast/audio.py
@@ -287,7 +287,8 @@ else:
     """
     if  codec == 'mp3':
 
-        if platform == 'Linux' and backends_dict[backend] != 'parec' and backends_dict[backend] != 'gstreamer':
+        if (platform == 'Linux' and backends_dict[backend] != 'parec' and
+                backends_dict[backend] != 'gstreamer'):
             command = [
                 backend,
                 '-ac', '2',
@@ -307,7 +308,8 @@ else:
             if segmenttime != None:
                 set_segmenttime()
 
-        elif platform == 'Linux' and backends_dict[backend] == 'parec' or backends_dict[backend] == 'gstreamer':
+        elif (platform == 'Linux' and backends_dict[backend] == 'parec' or
+        backends_dict[backend] == 'gstreamer'):
             command = [
                 'lame',
                 '-b', bitrate[:-1],
@@ -360,7 +362,8 @@ else:
     OGG 192k
     """
     if  codec == 'ogg':
-        if platform == 'Linux' and backends_dict[backend] != 'parec' and backends_dict[backend] != 'gstreamer':
+        if (platform == 'Linux' and backends_dict[backend] != 'parec' and
+                backends_dict[backend] != 'gstreamer'):
             command = [
                 backend,
                 '-ac', '2',
@@ -380,7 +383,8 @@ else:
             if segmenttime != None:
                 set_segmenttime()
 
-        elif platform == 'Linux' and backends_dict[backend] == 'parec' or backends_dict[backend] == 'gstreamer':
+        elif (platform == 'Linux' and backends_dict[backend] == 'parec' or
+                backends_dict[backend] == 'gstreamer'):
             command = [
                 'oggenc',
                 '-b', bitrate[:-1],
@@ -434,7 +438,8 @@ else:
     AAC > 128k for Stereo, Default sample rate: 44100kHz
     """
     if  codec == 'aac':
-        if platform == 'Linux' and backends_dict[backend] != 'parec' and backends_dict[backend] != 'gstreamer':
+        if (platform == 'Linux' and backends_dict[backend] != 'parec' and
+                backends_dict[backend] != 'gstreamer'):
             command = [
                 backend,
                 '-ac', '2',
@@ -452,7 +457,8 @@ else:
             if adevice != None:
                 modalsa()
 
-        elif platform == 'Linux' and backends_dict[backend] == 'parec' or backends_dict[backend] == 'gstreamer':
+        elif (platform == 'Linux' and backends_dict[backend] == 'parec' or
+                backends_dict[backend] == 'gstreamer'):
             command = [
                 'faac',
                 '-b', bitrate[:-1],
@@ -532,7 +538,8 @@ else:
             if segmenttime != None:
                 set_segmenttime()
 
-        elif platform == 'Linux' and backends_dict[backend] == 'parec' or backends_dict[backend] == 'gstreamer':
+        elif (platform == 'Linux' and backends_dict[backend] == 'parec' or
+                backends_dict[backend] == 'gstreamer'):
             command = [
                 'sox',
                 '-t', 'raw',
@@ -586,7 +593,8 @@ else:
             if segmenttime != None:
                 set_segmenttime()
 
-        elif platform == 'Linux' and backends_dict[backend] == 'parec' or backends_dict[backend] == 'gstreamer':
+        elif (platform == 'Linux' and backends_dict[backend] == 'parec' or
+                backends_dict[backend] == 'gstreamer'):
             command = [
                 'flac',
                 '-',

--- a/mkchromecast/audio.py
+++ b/mkchromecast/audio.py
@@ -130,8 +130,6 @@ else:
 
     if codec == 'mp3':
         appendmtype = 'mpeg'
-    elif codec == 'aac':
-        appendmtype = 'mp4' #This is the container used for aac
     else:
         appendmtype = codec
 

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -125,9 +125,16 @@ class casting(object):
         from pychromecast import socket_client  # This fixes the `No handlers could be found for logger "pychromecast.socket_client` warning"`.
                                                 # See commit 18005ebd4c96faccd69757bf3d126eb145687e0d.
         self.cclist = self._get_chromecasts()
+        self.cclist = [ [index, _, 'Gcast'] for index, _ in enumerate(self.cclist) ]
 
         if sonos == True:
             self.sonos_list = list(soco.discover())
+            lenght = len(self.cclist)
+
+            for self.index, device in enumerate(self.sonos_list):
+                add_sonos = [self.index, device, 'Sonos']
+                self.cclist.append(add_sonos)
+
         if self.debug == True:
             print('self.cclist', self.cclist)
 
@@ -145,21 +152,16 @@ class casting(object):
             if self.debug == True:
                 print('if len(self.cclist) != 0 and self.select_cc == False:')
             print(' ')
-            print(colors.important('List of Google Cast devices available in your network:'))
-            print(colors.important('------------------------------------------------------'))
-            print(' ')
-            print(colors.important('Index   Friendly name'))
-            print(colors.important('=====   ============= '))
-            for self.index,device in enumerate(self.cclist):
-                try:
-                    print(str(self.index)+'      ', str(device))
-                except UnicodeEncodeError:
-                    print(str(self.index)+'      ', str(unicode(device).encode("utf-8")))
+            print(colors.important('List of Devices Available in your Network:'))
+            print(colors.important('------------------------------------------\n'))
+            print(colors.important('Index \tTypes \tFriendly Name '))
+            print(colors.important('===== \t===== \t============= '))
+            self.availablecc()
             print(' ')
             if self.discover == False:
                 print(colors.important('We will cast to first device in the list above!'))
                 print(' ')
-                self.cast_to = self.cclist[0]
+                self.cast_to = self.cclist[0][1]
                 print(colors.success(self.cast_to))
                 print(' ')
 
@@ -169,11 +171,10 @@ class casting(object):
             if os.path.exists('/tmp/mkchromecast.tmp') == False:
                 self.tf = open('/tmp/mkchromecast.tmp', 'wb')
                 print(' ')
-                print(colors.important('List of devices available in your network:'))
-                print(colors.important('------------------------------------------'))
-                print(' ')
-                print(colors.important('Index   Types  Friendly name '))
-                print(colors.important('=====   =====  ============= '))
+                print(colors.important('List of Devices Available in your Network:'))
+                print(colors.important('------------------------------------------\n'))
+                print(colors.important('Index \tTypes \tFriendly Name '))
+                print(colors.important('===== \t===== \t============= '))
                 self.availablecc()
             else:
                 if self.debug == True:
@@ -191,11 +192,10 @@ class casting(object):
             if os.path.exists('/tmp/mkchromecast.tmp') == False:
                 self.tf = open('/tmp/mkchromecast.tmp', 'wb')
                 print(' ')
-                print(colors.important('List of Google Cast devices available in your network:'))
-                print(colors.important('------------------------------------------------------'))
-                print(' ')
-                print(colors.important('Index   Friendly name'))
-                print(colors.important('=====   ============= '))
+                print(colors.important('List of Devices Available in your Network:'))
+                print(colors.important('------------------------------------------\n'))
+                print(colors.important('Index \tTypes \tFriendly Name '))
+                print(colors.important('===== \t===== \t============= '))
                 self.availablecc()
             else:
                 if self.debug == True:
@@ -234,10 +234,12 @@ class casting(object):
             try:
                 pickle.dump(self.index, self.tf)
                 self.tf.close()
-                self.cast_to = self.cclist[int(self.index)]
+                self.cast_to = self.cclist[int(self.index)][1]
                 print(' ')
                 print(colors.options('Casting to:')+' '+colors.success(self.cast_to))
                 print(' ')
+            except TypeError:
+                print(colors.options('Casting to:')+' '+colors.success(self.cast_to.player_name))
             except IndexError:
                 checkmktmp()
                 self.tf = open('/tmp/mkchromecast.tmp', 'wb')
@@ -248,115 +250,110 @@ class casting(object):
     def get_cc(self):
         if self.debug == True:
             print('def get_cc(self):')
-        try:
-            if self.ccname != None:
-                self.cast_to = self.ccname
-            self.cast = self._get_chromecast(self.cast_to)
-            # Wait for cast device to be ready
-            self.cast.wait()
-            print(' ')
-            print(colors.important('Information about ')+' '+colors.success(self.cast_to))
-            print(' ')
-            print(self.cast.device)
-            print(' ')
-            print(colors.important('Status of device ')+' '+colors.success(self.cast_to))
-            print(' ')
-            print(self.cast.status)
-            print(' ')
-        except pychromecast.error.NoChromecastFoundError:
-            print(colors.error('No Chromecasts matching filter critera were found!'))
-            if self.platform == 'Darwin':
-                inputint()
-                outputint()
-            elif self.platform == 'Linux':
-                from mkchromecast.pulseaudio import remove_sink
-                remove_sink()
-            if self.tray == False:  # In the case that the tray is used, we don't kill the application
-                print(colors.error('Finishing the application...'))
-                terminate()
-                exit()
-            else:
-                self.stop_cast()
+        if self.cclist[int(self.index)][2] == 'Gcast':
+            try:
+                if self.ccname != None:
+                    self.cast_to = self.ccname
+                self.cast = self._get_chromecast(self.cast_to)
+                # Wait for cast device to be ready
+                self.cast.wait()
+                print(' ')
+                print(colors.important('Information about ')+' '+colors.success(self.cast_to))
+                print(' ')
+                print(self.cast.device)
+                print(' ')
+                print(colors.important('Status of device ')+' '+colors.success(self.cast_to))
+                print(' ')
+                print(self.cast.status)
+                print(' ')
+            except pychromecast.error.NoChromecastFoundError:
+                print(colors.error('No Chromecasts matching filter critera were found!'))
+                if self.platform == 'Darwin':
+                    inputint()
+                    outputint()
+                elif self.platform == 'Linux':
+                    from mkchromecast.pulseaudio import remove_sink
+                    remove_sink()
+                if self.tray == False:  # In the case that the tray is used, we don't kill the application
+                    print(colors.error('Finishing the application...'))
+                    terminate()
+                    exit()
+                else:
+                    self.stop_cast()
+        else:
+            pass
 
     def play_cast(self):
+        print('play cast')
         if self.debug == True:
             print('def play_cast(self):')
         localip = self.ip
 
-        print(colors.options('The IP of ')+colors.success(self.cast_to)+colors.options(' is:')+' '+self.cast.host)
+        try:
+            print(colors.options('The IP of ')+colors.success(self.cast_to)+colors.options(' is:')+' '+self.cast.host)
+        except TypeError:
+            print(colors.options('The IP of ')+colors.success(self.cast_to.player_name)+colors.options(' is:')+' '+self.cast_to.ip_address)
+
         if self.host == None:
             print(colors.options('Your local IP is:')+' '+localip)
         else:
             print(colors.options('Your manually entered local IP is:')+' '+localip)
 
-        """
-        if self.youtubeurl != None:
-            print(colors.options('The Youtube URL chosen:')+' '+self.youtubeurl)
-            import pychromecast.controllers.youtube as youtube
-            yt = youtube.YouTubeController()
-            self.cast.register_handler(yt)
+        if self.cclist[int(self.index)][2] == 'Gcast':
+            media_controller = self.cast.media_controller
 
-            try:
-                import urlparse
-                url_data = urlparse.urlparse(self.youtubeurl)
-                query = urlparse.parse_qs(url_data.query)
-            except ImportError:
-                import urllib.parse
-                url_data = urllib.parse.urlparse(self.youtubeurl)
-                query = urllib.parse.parse_qs(url_data.query)
-            video = query["v"][0]
-            print(colors.options('Playing video:')+' '+video)
-            yt.play_video(video)
-        else:
-        """
-        media_controller = self.cast.media_controller
+            if self.tray == True:
+                config = ConfigParser.RawConfigParser()
+                configurations = config_manager()    # Class from mkchromecast.config
+                configf = configurations.configf
 
-        if self.tray == True:
-            config = ConfigParser.RawConfigParser()
-            configurations = config_manager()    # Class from mkchromecast.config
-            configf = configurations.configf
+                if os.path.exists(configf) and self.tray == True:
+                    print(tray)
+                    print(colors.warning('Configuration file exists'))
+                    print(colors.warning('Using defaults set there'))
+                    config.read(configf)
+                    self.backend = ConfigSectionMap('settings')['backend']
 
-            if os.path.exists(configf) and self.tray == True:
-                print(tray)
-                print(colors.warning('Configuration file exists'))
-                print(colors.warning('Using defaults set there'))
-                config.read(configf)
-                self.backend = ConfigSectionMap('settings')['backend']
-
-        if self.sourceurl != None:
-            if args.video == True:
-                import mkchromecast.video
-                mtype = mkchromecast.video.mtype
-            else:
-                import mkchromecast.audio
-                mtype = mkchromecast.audio.mtype
+            if self.sourceurl != None:
+                if args.video == True:
+                    import mkchromecast.video
+                    mtype = mkchromecast.video.mtype
+                else:
+                    import mkchromecast.audio
+                    mtype = mkchromecast.audio.mtype
+                print(' ')
+                print(colors.options('Casting from stream URL:')+' '+self.sourceurl)
+                print(colors.options('Using media type:')+' '+mtype)
+                media_controller.play_media(self.sourceurl, mtype, title = self.title)
+            elif (self.backend == 'ffmpeg' or self.backend == 'node' or self.backend == 'avconv' or
+                    self.backend == 'parec' or self.backend == 'gstreamer' and self.sourceurl == None):
+                if args.video == True:
+                    import mkchromecast.video
+                    mtype = mkchromecast.video.mtype
+                else:
+                    import mkchromecast.audio
+                    mtype = mkchromecast.audio.mtype
+                print(' ')
+                print(colors.options('The media type string used is:')+' '+mtype)
+                media_controller.play_media('http://'+localip+':5000/stream', mtype, title = self.title)
             print(' ')
-            print(colors.options('Casting from stream URL:')+' '+self.sourceurl)
-            print(colors.options('Using media type:')+' '+mtype)
-            media_controller.play_media(self.sourceurl, mtype, title = self.title)
-        elif (self.backend == 'ffmpeg' or self.backend == 'node' or self.backend == 'avconv' or
-                self.backend == 'parec' or self.backend == 'gstreamer' and self.sourceurl == None):
-            if args.video == True:
-                import mkchromecast.video
-                mtype = mkchromecast.video.mtype
-            else:
-                import mkchromecast.audio
-                mtype = mkchromecast.audio.mtype
+            print(colors.important('Cast media controller status'))
             print(' ')
-            print(colors.options('The media type string used is:')+' '+mtype)
-            media_controller.play_media('http://'+localip+':5000/stream', mtype, title = self.title)
-        print(' ')
-        print(colors.important('Cast media controller status'))
-        print(' ')
-        print(self.cast.status)
-        print(' ')
-        if self.reconnect == True:
-            self.r = Thread(target = self.reconnect_cc)
-            self.r.daemon = True   # This has to be set to True so that we catch KeyboardInterrupt.
-            self.r.start()
+            print(self.cast.status)
+            print(' ')
+            if self.reconnect == True:
+                self.r = Thread(target = self.reconnect_cc)
+                self.r.daemon = True   # This has to be set to True so that we catch KeyboardInterrupt.
+                self.r.start()
+        elif self.cclist[int(self.index)][2] == 'Sonos':
+            self.sonos = self.cast_to
+            self.sonos.play_uri('x-rincon-mp3radio://'+localip+':5000/stream')
 
     def stop_cast(self):
-        self.cast.quit_app()
+        if self.cclist[int(self.index)][2] == 'Gcast':
+            self.cast.quit_app()
+        else:
+            self.sonos.stop()
 
     def volume_up(self):
         """ Increment volume by 0.1 unless it is already maxed.
@@ -388,25 +385,23 @@ class casting(object):
         needed for the system tray.
         """
         self.availablecc=[]
-        for self.index,device in enumerate(self.cclist):
+        for (self.index, device) in enumerate(self.cclist):
             try:
-                print(str(self.index)+'       Gcast ', str(device))
+                types = device[2]
+                if types == 'Sonos':
+                    device = device[1].player_name
+                else:
+                    device = device[1]
+                print('%s \t%s \t%s' % (self.index, types, device))
             except UnicodeEncodeError:
-                print(str(self.index)+'       Gcast ', str(unicode(device).encode("utf-8")))
-            to_append = [self.index,device]
+                types = device[2]
+                if types == 'Sonos':
+                    device = device[1].player_name
+                else:
+                    device = device[1]
+                print('%s \t%s \t%s' % (self.index, device[2], str(unicode(device).encode("utf-8"))))
+            to_append = [self.index, device]
             self.availablecc.append(to_append)
-
-        if sonos == True:
-            lenght = len(self.availablecc)
-            for self.index,device in enumerate(self.sonos_list):
-                try:
-                    self.index = self.index + lenght
-                    print(str(self.index)+'       Sonos ', str(device.player_name))
-                except UnicodeEncodeError:
-                    self.index = self.index + lenght
-                    print(str(self.index)+'       Sonos ', str(unicode(device.player_name).encode("utf-8")))
-                to_append = [self.index,device]
-                self.availablecc.append(to_append)
 
     def reconnect_cc(self):
         """Dummy method to call  _reconnect_cc_().

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -282,6 +282,8 @@ class casting(object):
                 self.stop_cast()
         except AttributeError:
             pass
+        except KeyError:
+            pass
 
     def play_cast(self):
         if self.debug == True:

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -206,6 +206,9 @@ class casting(object):
                 print(' ')
                 print(colors.options('Casting to:')+' '+colors.success(self.cast_to))
                 print(' ')
+                for _ in self.cclist:
+                    if self.cast_to in _:
+                        self.types = _[2]
 
         elif len(self.cclist) == 0 and self.tray == False:
             if self.debug == True:
@@ -250,7 +253,7 @@ class casting(object):
     def get_cc(self):
         if self.debug == True:
             print('def get_cc(self):')
-        if self.cclist[int(self.index)][2] == 'Gcast':
+        if self.cclist[int(self.index)][2] == 'Gcast' or self.types == 'Gcast':
             try:
                 if self.ccname != None:
                     self.cast_to = self.ccname
@@ -284,7 +287,6 @@ class casting(object):
             pass
 
     def play_cast(self):
-        print('play cast')
         if self.debug == True:
             print('def play_cast(self):')
         localip = self.ip
@@ -299,7 +301,7 @@ class casting(object):
         else:
             print(colors.options('Your manually entered local IP is:')+' '+localip)
 
-        if self.cclist[int(self.index)][2] == 'Gcast':
+        if self.cclist[int(self.index)][2] == 'Gcast' or self.types == 'Gcast':
             media_controller = self.cast.media_controller
 
             if self.tray == True:
@@ -400,7 +402,7 @@ class casting(object):
                 else:
                     device = device[1]
                 print('%s \t%s \t%s' % (self.index, device[2], str(unicode(device).encode("utf-8"))))
-            to_append = [self.index, device]
+            to_append = [self.index, device, types]
             self.availablecc.append(to_append)
 
     def reconnect_cc(self):

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -291,6 +291,11 @@ class casting(object):
             print(colors.options('The IP of ')+colors.success(self.cast_to)+colors.options(' is:')+' '+self.cast.host)
         except TypeError:
             print(colors.options('The IP of ')+colors.success(self.cast_to.player_name)+colors.options(' is:')+' '+self.cast_to.ip_address)
+        except AttributeError:
+            for _ in self.sonos_list:
+                if self.cast_to in _.player_name:
+                    self.cast_to = _
+            print(colors.options('The IP of ')+colors.success(self.cast_to.player_name)+colors.options(' is:')+' '+self.cast_to.ip_address)
 
         if self.host == None:
             print(colors.options('Your local IP is:')+' '+localip)
@@ -348,9 +353,9 @@ class casting(object):
             self.sonos.play_uri('x-rincon-mp3radio://'+localip+':5000/stream')
 
     def stop_cast(self):
-        if self.cclist[int(self.index)][2] == 'Gcast':
+        try:
             self.cast.quit_app()
-        else:
+        except AttributeError:
             self.sonos.stop()
 
     def volume_up(self):

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -9,6 +9,7 @@ import mkchromecast.colors as colors
 from mkchromecast.config import *
 from mkchromecast.preferences import ConfigSectionMap
 from mkchromecast.utils import terminate
+from mkchromecast.pulseaudio import remove_sink
 import time
 import pychromecast
 from pychromecast.dial import reboot
@@ -214,7 +215,6 @@ class casting(object):
                 print('elif len(self.cclist) == 0 and self.tray == False:')
             print(colors.error('No devices found!'))
             if self.platform == 'Linux' and self.adevice == None:
-                from mkchromecast.pulseaudio import remove_sink
                 remove_sink()
             elif self.platform == 'Darwin':
                 inputint()
@@ -273,7 +273,6 @@ class casting(object):
                 inputint()
                 outputint()
             elif self.platform == 'Linux':
-                from mkchromecast.pulseaudio import remove_sink
                 remove_sink()
             if self.tray == False:  # In the case that the tray is used, we don't kill the application
                 print(colors.error('Finishing the application...'))
@@ -431,7 +430,6 @@ class casting(object):
                 inputint()
                 outputint()
             elif platform == 'Linux' and adevice == None:
-                from mkchromecast.pulseaudio import remove_sink
                 remove_sink()
             terminate()
 

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -27,6 +27,15 @@ try:
 except ImportError:
     import configparser as ConfigParser # This is for Python3
 
+"""
+We verify that soco is installed to give Sonos support
+"""
+try:
+    import soco
+    sonos = True
+except ImportError:
+    sonos = False
+
 class casting(object):
     """Main casting class.
     """
@@ -116,6 +125,9 @@ class casting(object):
         from pychromecast import socket_client  # This fixes the `No handlers could be found for logger "pychromecast.socket_client` warning"`.
                                                 # See commit 18005ebd4c96faccd69757bf3d126eb145687e0d.
         self.cclist = self._get_chromecasts()
+
+        if sonos == True:
+            self.sonos_list = list(soco.discover())
         if self.debug == True:
             print('self.cclist', self.cclist)
 
@@ -157,11 +169,11 @@ class casting(object):
             if os.path.exists('/tmp/mkchromecast.tmp') == False:
                 self.tf = open('/tmp/mkchromecast.tmp', 'wb')
                 print(' ')
-                print(colors.important('List of Google Cast devices available in your network:'))
-                print(colors.important('------------------------------------------------------'))
+                print(colors.important('List of devices available in your network:'))
+                print(colors.important('------------------------------------------'))
                 print(' ')
-                print(colors.important('Index   Friendly name'))
-                print(colors.important('=====   ============= '))
+                print(colors.important('Index   Types  Friendly name '))
+                print(colors.important('=====   =====  ============= '))
                 self.availablecc()
             else:
                 if self.debug == True:
@@ -378,11 +390,23 @@ class casting(object):
         self.availablecc=[]
         for self.index,device in enumerate(self.cclist):
             try:
-                print(str(self.index)+'      ', str(device))
+                print(str(self.index)+'       Gcast ', str(device))
             except UnicodeEncodeError:
-                print(str(self.index)+'      ', str(unicode(device).encode("utf-8")))
+                print(str(self.index)+'       Gcast ', str(unicode(device).encode("utf-8")))
             to_append = [self.index,device]
             self.availablecc.append(to_append)
+
+        if sonos == True:
+            lenght = len(self.availablecc)
+            for self.index,device in enumerate(self.sonos_list):
+                try:
+                    self.index = self.index + lenght
+                    print(str(self.index)+'       Sonos ', str(device.player_name))
+                except UnicodeEncodeError:
+                    self.index = self.index + lenght
+                    print(str(self.index)+'       Sonos ', str(unicode(device.player_name).encode("utf-8")))
+                to_append = [self.index,device]
+                self.availablecc.append(to_append)
 
     def reconnect_cc(self):
         """Dummy method to call  _reconnect_cc_().

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -152,7 +152,8 @@ class casting(object):
             self.youtubeurl = None
         """
 
-        if len(self.cclist) != 0 and self.select_cc == False and self.ccname == None:
+        if (len(self.cclist) != 0 and self.select_cc == False and
+                self.ccname == None):
             if self.debug == True:
                 print('if len(self.cclist) != 0 and self.select_cc == False:')
             print(' ')
@@ -169,7 +170,8 @@ class casting(object):
                 print(colors.success(self.cast_to))
                 print(' ')
 
-        elif len(self.cclist) != 0 and self.select_cc == True and self.tray == False and self.ccname == None:
+        elif (len(self.cclist) != 0 and self.select_cc == True and
+                self.tray == False and self.ccname == None):
             if self.debug == True:
                 print('elif len(self.cclist) != 0 and self.select_cc == True and self.tray == False:')
             if os.path.exists('/tmp/mkchromecast.tmp') == False:
@@ -190,7 +192,8 @@ class casting(object):
                 print(colors.options('Casting to:')+' '+colors.success(self.cast_to))
                 print(' ')
 
-        elif len(self.cclist) != 0 and self.select_cc == True and self.tray == True:
+        elif (len(self.cclist) != 0 and self.select_cc == True and
+                self.tray == True):
             if self.debug == True:
                 print('elif len(self.cclist) != 0 and self.select_cc == True and self.tray == True:')
             if os.path.exists('/tmp/mkchromecast.tmp') == False:
@@ -229,7 +232,7 @@ class casting(object):
 
     def sel_cc(self):
         print(' ')
-        print('Please, select the '+colors.important('Index')+' of the Google Cast device that you want to use:')
+        print('Please, select the ' + colors.important('Index') + ' of the Google Cast device that you want to use:')
         self.index = input()
 
     def inp_cc(self):
@@ -239,10 +242,10 @@ class casting(object):
                 self.tf.close()
                 self.cast_to = self.cclist[int(self.index)][1]
                 print(' ')
-                print(colors.options('Casting to:')+' '+colors.success(self.cast_to))
+                print(colors.options('Casting to:') + ' ' + colors.success(self.cast_to))
                 print(' ')
             except TypeError:
-                print(colors.options('Casting to:')+' '+colors.success(self.cast_to.player_name))
+                print(colors.options('Casting to:') + ' ' + colors.success(self.cast_to.player_name))
             except IndexError:
                 checkmktmp()
                 self.tf = open('/tmp/mkchromecast.tmp', 'wb')
@@ -260,11 +263,11 @@ class casting(object):
             # Wait for cast device to be ready
             self.cast.wait()
             print(' ')
-            print(colors.important('Information about ')+' '+colors.success(self.cast_to))
+            print(colors.important('Information about ') + ' ' + colors.success(self.cast_to))
             print(' ')
             print(self.cast.device)
             print(' ')
-            print(colors.important('Status of device ')+' '+colors.success(self.cast_to))
+            print(colors.important('Status of device ') + ' ' + colors.success(self.cast_to))
             print(' ')
             print(self.cast.status)
             print(' ')
@@ -292,19 +295,25 @@ class casting(object):
         localip = self.ip
 
         try:
-            print(colors.options('The IP of ')+colors.success(self.cast_to)+colors.options(' is:')+' '+self.cast.host)
+            print(colors.options('The IP of ')
+                    + colors.success(self.cast_to)+colors.options(' is:')
+                    + ' ' + self.cast.host)
         except TypeError:
-            print(colors.options('The IP of ')+colors.success(self.cast_to.player_name)+colors.options(' is:')+' '+self.cast_to.ip_address)
+            print(colors.options('The IP of ')
+                    + colors.success(self.cast_to.player_name)
+                    + colors.options(' is:') + ' ' + self.cast_to.ip_address)
         except AttributeError:
             for _ in self.sonos_list:
                 if self.cast_to in _.player_name:
                     self.cast_to = _
-            print(colors.options('The IP of ')+colors.success(self.cast_to.player_name)+colors.options(' is:')+' '+self.cast_to.ip_address)
+            print(colors.options('The IP of ')
+                    + colors.success(self.cast_to.player_name)
+                    + colors.options(' is:') + ' ' + self.cast_to.ip_address)
 
         if self.host == None:
-            print(colors.options('Your local IP is:')+' '+localip)
+            print(colors.options('Your local IP is:') + ' ' + localip)
         else:
-            print(colors.options('Your manually entered local IP is:')+' '+localip)
+            print(colors.options('Your manually entered local IP is:') + ' ' + localip)
 
         try:
             media_controller = self.cast.media_controller
@@ -329,11 +338,12 @@ class casting(object):
                     import mkchromecast.audio
                     mtype = mkchromecast.audio.mtype
                 print(' ')
-                print(colors.options('Casting from stream URL:')+' '+self.sourceurl)
-                print(colors.options('Using media type:')+' '+mtype)
-                media_controller.play_media(self.sourceurl, mtype, title = self.title)
-            elif (self.backend == 'ffmpeg' or self.backend == 'node' or self.backend == 'avconv' or
-                    self.backend == 'parec' or self.backend == 'gstreamer' and self.sourceurl == None):
+                print(colors.options('Casting from stream URL:') + ' ' + self.sourceurl)
+                print(colors.options('Using media type:') + ' ' + mtype)
+                media_controller.play_media(self.sourceurl, mtype, title=self.title)
+            elif (self.backend == 'ffmpeg' or self.backend == 'node' or
+                    self.backend == 'avconv' or self.backend == 'parec' or
+                    self.backend == 'gstreamer' and self.sourceurl == None):
                 if args.video == True:
                     import mkchromecast.video
                     mtype = mkchromecast.video.mtype
@@ -341,20 +351,20 @@ class casting(object):
                     import mkchromecast.audio
                     mtype = mkchromecast.audio.mtype
                 print(' ')
-                print(colors.options('The media type string used is:')+' '+mtype)
-                media_controller.play_media('http://'+localip+':5000/stream', mtype, title = self.title)
+                print(colors.options('The media type string used is:') + ' ' + mtype)
+                media_controller.play_media('http://' + localip + ':5000/stream', mtype, title=self.title)
             print(' ')
             print(colors.important('Cast media controller status'))
             print(' ')
             print(self.cast.status)
             print(' ')
             if self.reconnect == True:
-                self.r = Thread(target = self.reconnect_cc)
+                self.r = Thread(target=self.reconnect_cc)
                 self.r.daemon = True   # This has to be set to True so that we catch KeyboardInterrupt.
                 self.r.start()
         except AttributeError:
             self.sonos = self.cast_to
-            self.sonos.play_uri('x-rincon-mp3radio://'+localip+':5000/stream', title=self.title)
+            self.sonos.play_uri('x-rincon-mp3radio://' + localip + ':5000/stream', title=self.title)
             if self.tray == True:
                 self.cast = self.sonos
 
@@ -390,7 +400,7 @@ class casting(object):
 
     def reboot(self):
         if self.platform == 'Darwin':
-            self.cast.host = socket.gethostbyname(self.cast_to+'.local')
+            self.cast.host = socket.gethostbyname(self.cast_to + '.local')
             reboot(self.cast.host)
         else:
             print(colors.error('This method is not supported in Linux yet.'))
@@ -465,7 +475,7 @@ def ping_chromecast(ip):
     Credits: http://stackoverflow.com/a/34455969/1995261
     """
     try:
-        output = subprocess.check_output("ping -c 1 "+ip, shell=True)
+        output = subprocess.check_output("ping -c 1 " + ip, shell=True)
     except:
         return False
     return True

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -206,9 +206,6 @@ class casting(object):
                 print(' ')
                 print(colors.options('Casting to:')+' '+colors.success(self.cast_to))
                 print(' ')
-                for _ in self.cclist:
-                    if self.cast_to in _:
-                        self.types = _[2]
 
         elif len(self.cclist) == 0 and self.tray == False:
             if self.debug == True:
@@ -243,7 +240,6 @@ class casting(object):
                 print(' ')
             except TypeError:
                 print(colors.options('Casting to:')+' '+colors.success(self.cast_to.player_name))
-                self.types = 'Sonos'
             except IndexError:
                 checkmktmp()
                 self.tf = open('/tmp/mkchromecast.tmp', 'wb')
@@ -254,37 +250,36 @@ class casting(object):
     def get_cc(self):
         if self.debug == True:
             print('def get_cc(self):')
-        if self.cclist[int(self.index)][2] == 'Gcast' or self.types == 'Gcast':
-            try:
-                if self.ccname != None:
-                    self.cast_to = self.ccname
-                self.cast = self._get_chromecast(self.cast_to)
-                # Wait for cast device to be ready
-                self.cast.wait()
-                print(' ')
-                print(colors.important('Information about ')+' '+colors.success(self.cast_to))
-                print(' ')
-                print(self.cast.device)
-                print(' ')
-                print(colors.important('Status of device ')+' '+colors.success(self.cast_to))
-                print(' ')
-                print(self.cast.status)
-                print(' ')
-            except pychromecast.error.NoChromecastFoundError:
-                print(colors.error('No Chromecasts matching filter critera were found!'))
-                if self.platform == 'Darwin':
-                    inputint()
-                    outputint()
-                elif self.platform == 'Linux':
-                    from mkchromecast.pulseaudio import remove_sink
-                    remove_sink()
-                if self.tray == False:  # In the case that the tray is used, we don't kill the application
-                    print(colors.error('Finishing the application...'))
-                    terminate()
-                    exit()
-                else:
-                    self.stop_cast()
-        else:
+        try:
+            if self.ccname != None:
+                self.cast_to = self.ccname
+            self.cast = self._get_chromecast(self.cast_to)
+            # Wait for cast device to be ready
+            self.cast.wait()
+            print(' ')
+            print(colors.important('Information about ')+' '+colors.success(self.cast_to))
+            print(' ')
+            print(self.cast.device)
+            print(' ')
+            print(colors.important('Status of device ')+' '+colors.success(self.cast_to))
+            print(' ')
+            print(self.cast.status)
+            print(' ')
+        except pychromecast.error.NoChromecastFoundError:
+            print(colors.error('No Chromecasts matching filter critera were found!'))
+            if self.platform == 'Darwin':
+                inputint()
+                outputint()
+            elif self.platform == 'Linux':
+                from mkchromecast.pulseaudio import remove_sink
+                remove_sink()
+            if self.tray == False:  # In the case that the tray is used, we don't kill the application
+                print(colors.error('Finishing the application...'))
+                terminate()
+                exit()
+            else:
+                self.stop_cast()
+        except AttributeError:
             pass
 
     def play_cast(self):
@@ -302,7 +297,7 @@ class casting(object):
         else:
             print(colors.options('Your manually entered local IP is:')+' '+localip)
 
-        if self.cclist[int(self.index)][2] == 'Gcast' or self.types == 'Gcast':
+        try:
             media_controller = self.cast.media_controller
 
             if self.tray == True:
@@ -348,7 +343,7 @@ class casting(object):
                 self.r = Thread(target = self.reconnect_cc)
                 self.r.daemon = True   # This has to be set to True so that we catch KeyboardInterrupt.
                 self.r.start()
-        elif self.cclist[int(self.index)][2] == 'Sonos':
+        except AttributeError:
             self.sonos = self.cast_to
             self.sonos.play_uri('x-rincon-mp3radio://'+localip+':5000/stream')
 
@@ -362,19 +357,25 @@ class casting(object):
         """ Increment volume by 0.1 unless it is already maxed.
         Returns the new volume.
         """
-        print('Increasing volume...')
-        print(' ')
-        volume = round(self.cast.status.volume_level, 1)
-        return self.cast.set_volume(volume + 0.1)
+        print('Increasing volume... \n')
+        try:
+            volume = round(self.cast.status.volume_level, 1)
+            return self.cast.set_volume(volume + 0.1)
+        except AttributeError:
+            self.sonos.volume += 1
+            self.sonos.play()
 
     def volume_down(self):
         """ Decrement the volume by 0.1 unless it is already 0.
         Returns the new volume.
         """
-        print('Decreasing volume...')
-        print(' ')
-        volume = round(self.cast.status.volume_level, 1)
-        return self.cast.set_volume(volume - 0.1)
+        print('Decreasing volume... \n')
+        try:
+            volume = round(self.cast.status.volume_level, 1)
+            return self.cast.set_volume(volume - 0.1)
+        except AttributeError:
+            self.sonos.volume -= 1
+            self.sonos.play()
 
     def reboot(self):
         if self.platform == 'Darwin':

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -37,6 +37,7 @@ try:
 except ImportError:
     sonos = False
 
+
 class casting(object):
     """Main casting class.
     """
@@ -53,7 +54,7 @@ class casting(object):
         self.host = mkchromecast.__init__.host
         self.ccname = mkchromecast.__init__.ccname
         self.reconnect = mkchromecast.__init__.reconnect
-        self.title = 'Mkchromecast v'+mkchromecast.__init__.__version__
+        self.title = 'Mkchromecast v' + mkchromecast.__init__.__version__
 
         if self.host == None:
             if self.platform == 'Linux':

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -243,6 +243,7 @@ class casting(object):
                 print(' ')
             except TypeError:
                 print(colors.options('Casting to:')+' '+colors.success(self.cast_to.player_name))
+                self.types = 'Sonos'
             except IndexError:
                 checkmktmp()
                 self.tf = open('/tmp/mkchromecast.tmp', 'wb')

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -409,11 +409,12 @@ class casting(object):
         """This method is used for populating the self.availablecc array
         needed for the system tray.
         """
-        self.availablecc=[]
+        self.availablecc = []
         for (self.index, device) in enumerate(self.cclist):
             try:
                 types = device[2]
                 if types == 'Sonos':
+                    device_ip = device[1].ip_address
                     device = device[1].player_name
                 else:
                     device = device[1]
@@ -421,11 +422,16 @@ class casting(object):
             except UnicodeEncodeError:
                 types = device[2]
                 if types == 'Sonos':
+                    device_ip = device[1].ip_address
                     device = device[1].player_name
                 else:
                     device = device[1]
                 print('%s \t%s \t%s' % (self.index, device[2], str(unicode(device).encode("utf-8"))))
-            to_append = [self.index, device, types]
+
+            if types == 'Sonos':
+                to_append = [self.index, device, types, device_ip]
+            else:
+                to_append = [self.index, device, types]
             self.availablecc.append(to_append)
 
     def reconnect_cc(self):

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -352,6 +352,8 @@ class casting(object):
         except AttributeError:
             self.sonos = self.cast_to
             self.sonos.play_uri('x-rincon-mp3radio://'+localip+':5000/stream')
+            if self.tray == True:
+                self.cast = self.sonos
 
     def stop_cast(self):
         try:

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -353,7 +353,7 @@ class casting(object):
                 self.r.start()
         except AttributeError:
             self.sonos = self.cast_to
-            self.sonos.play_uri('x-rincon-mp3radio://'+localip+':5000/stream')
+            self.sonos.play_uri('x-rincon-mp3radio://'+localip+':5000/stream', title=self.title)
             if self.tray == True:
                 self.cast = self.sonos
 

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -128,12 +128,14 @@ class casting(object):
         self.cclist = [ [index, _, 'Gcast'] for index, _ in enumerate(self.cclist) ]
 
         if sonos == True:
-            self.sonos_list = list(soco.discover())
-            lenght = len(self.cclist)
-
-            for self.index, device in enumerate(self.sonos_list):
-                add_sonos = [self.index, device, 'Sonos']
-                self.cclist.append(add_sonos)
+            try:
+                self.sonos_list = list(soco.discover())
+                lenght = len(self.cclist)
+                for self.index, device in enumerate(self.sonos_list):
+                    add_sonos = [self.index, device, 'Sonos']
+                    self.cclist.append(add_sonos)
+            except TypeError:
+                pass
 
         if self.debug == True:
             print('self.cclist', self.cclist)

--- a/mkchromecast/preferences.py
+++ b/mkchromecast/preferences.py
@@ -21,7 +21,10 @@ tray = mkchromecast.__init__.tray
 USER = getpass.getuser()
 
 if platform == 'Darwin':
-    PATH ='./bin:./nodejs/bin:/Users/'+str(USER)+'/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/usr/X11/bin:/usr/games:'+ os.environ['PATH']
+    PATH ='./bin:./nodejs/bin:/Users/' + \
+            str(USER) + \
+            '/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/usr/X11/bin:/usr/games:' + \
+            os.environ['PATH']
 else:
     PATH = os.environ['PATH']
 
@@ -55,7 +58,8 @@ def ConfigSectionMap(section):
     return dict1
 
 if tray == True:
-    from PyQt5.QtWidgets import QWidget, QLabel, QComboBox, QApplication, QPushButton, QLineEdit
+    from PyQt5.QtWidgets import (QWidget, QLabel, QComboBox, QApplication,
+            QPushButton, QLineEdit)
     from PyQt5 import QtCore
 
     class preferences(QWidget):
@@ -102,13 +106,16 @@ if tray == True:
             self.backends = []
             if platform == 'Darwin':
                 for item in backends_supported:
-                    if is_installed(item, PATH, debug) == True and item != 'avconv' and item !='gstreamer':
+                    if (is_installed(item, PATH, debug) == True
+                            and item != 'avconv' and item !='gstreamer'):
                         self.backends.append(item)
             else:
                 for item in backends_supported:
-                    if is_installed(item, PATH, debug) == True and item != 'node' and item != 'gstreamer':
+                    if (is_installed(item, PATH, debug) == True
+                            and item != 'node' and item != 'gstreamer'):
                         self.backends.append(item)
-                    elif is_installed('gst-launch-1.0', PATH, debug) == True and item == 'gstreamer': # Hardcoded gst-launch-1.0 for gstreamer
+                    elif (is_installed('gst-launch-1.0', path, debug) == true and
+                            item == 'gstreamer'): # hardcoded gst-launch-1.0 for gstreamer
                         self.backends.append(item)
             backendindex = self.backends.index(self.backendconf)
             self.backend = QLabel('Select Backend', self)
@@ -126,7 +133,7 @@ if tray == True:
             Codec
             """
             self.codec = QLabel('Audio Coding Format', self)
-            self.codec.move(20*self.scale_factor, 56*self.scale_factor)
+            self.codec.move(20 * self.scale_factor, 56 * self.scale_factor)
             self.qccodec = QComboBox(self)
             self.qccodec.clear()
             if self.backendconf == 'node':
@@ -154,10 +161,10 @@ if tray == True:
             Bitrate
             """
             self.bitrate = QLabel('Select Bitrate (kbit/s)', self)
-            self.bitrate.move(20*self.scale_factor, 88*self.scale_factor)
+            self.bitrate.move(20 * self.scale_factor, 88 * self.scale_factor)
             self.qcbitrate = QComboBox(self)
             self.qcbitrate.clear()
-            self.qcbitrate.move(180*self.scale_factor, 88*self.scale_factor)
+            self.qcbitrate.move(180 * self.scale_factor, 88 * self.scale_factor)
             self.qcbitrate.setMinimumContentsLength(7)
             if self.codecconf == 'wav':
                 self.bitrates = ['None']

--- a/mkchromecast/pulseaudio.py
+++ b/mkchromecast/pulseaudio.py
@@ -53,3 +53,20 @@ def remove_sink():
             )
     rmsoutput, rmserror = rms.communicate()
     return
+
+def check_sink():
+    check_sink = [
+        'pacmd',
+        'list-sinks'
+        ]
+    chk = subprocess.Popen(
+            check_sink,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+            )
+    chkoutput, chkerror = chk.communicate()
+
+    if 'mkchromecast' in chkoutput:
+        return True
+    else:
+        return False

--- a/mkchromecast/pulseaudio.py
+++ b/mkchromecast/pulseaudio.py
@@ -66,7 +66,13 @@ def check_sink():
             )
     chkoutput, chkerror = chk.communicate()
 
-    if 'mkchromecast' in chkoutput:
-        return True
-    else:
-        return False
+    try:
+        if 'mkchromecast' in chkoutput:
+            return True
+        else:
+            return False
+    except TypeError:
+        if 'mkchromecast' in chkoutput.decode('utf-8'):
+            return True
+        else:
+            return False

--- a/mkchromecast/systray.py
+++ b/mkchromecast/systray.py
@@ -35,6 +35,13 @@ try:
 except ImportError:
     import configparser as ConfigParser # This is for Python3
 
+"""
+urllib is imported differently in Python3
+"""
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
 
 platform = mkchromecast.__init__.platform
 debug = mkchromecast.__init__.debug
@@ -755,12 +762,20 @@ class menubar(QtWidgets.QMainWindow):
                 pass    # I should add a notification here
         else:
             try:
-                print('Cast device IP: '+str(self.cast.host))
+                print('Cast device IP: %s' % str(self.cast.host))
                 self.reset_audio()
                 self.stop_cast()
                 reboot(self.cast.host)
             except AttributeError:
-                pass    # I should add a notification here
+                self.reset_audio()
+                self.stop_cast()
+                for device in self.availablecc:
+                    if self.cast_to in device:
+                        ip = device[3]
+                        print('Cast device IP: %s' % str(ip))
+                url = 'http://' + ip + ':1400/reboot'
+                urlopen(url).read()
+
 
     def preferences_show(self):
         self.p = mkchromecast.preferences.preferences(self.scale_factor)
@@ -844,7 +859,7 @@ class menubar(QtWidgets.QMainWindow):
         <br>
         <br>
         <br>
-        Copyright (c) 2016, Muammar El Khatib.
+        Copyright (c) 2017, Muammar El Khatib.
         <br>
         <br>
         This program comes with absolutely no warranty.

--- a/mkchromecast/systray.py
+++ b/mkchromecast/systray.py
@@ -14,8 +14,9 @@ import mkchromecast.preferences
 from mkchromecast.pulseaudio import *
 import mkchromecast.tray_threading
 from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import QThread, QObject, pyqtSignal, pyqtSlot, Qt
-from PyQt5.QtWidgets import QWidget, QSlider, QLabel, QApplication, QMessageBox, QMainWindow
+from PyQt5.QtCore import (QThread, QObject, pyqtSignal, pyqtSlot, Qt)
+from PyQt5.QtWidgets import (QWidget, QSlider, QLabel, QApplication,
+        QMessageBox, QMainWindow)
 from PyQt5.QtGui import QPixmap
 import pychromecast
 from pychromecast.dial import reboot
@@ -203,7 +204,7 @@ class menubar(QtWidgets.QMainWindow):
                 print(':::systray::: self.colors '+self.colors)
 
     def search_menu(self):
-        self.SearchAction = self.menu.addAction('Search For Google Cast Devices')
+        self.SearchAction = self.menu.addAction('Search For Media Streaming Devices')
         self.SearchAction.triggered.connect(self.search_cast)
 
     def stop_menu(self):
@@ -408,7 +409,7 @@ class menubar(QtWidgets.QMainWindow):
                     '-title',
                     'mkchromecast',
                     '-message',
-                    'Google Cast Devices Found'
+                    'Media Streaming Devices Found!'
                     ]
                 subprocess.Popen(found)
                 if debug == True:
@@ -421,7 +422,7 @@ class menubar(QtWidgets.QMainWindow):
                     Notify.init('mkchromecast')
                     found=Notify.Notification.new(
                         'mkchromecast',
-                        'Google Cast Devices Found!',
+                        'Media Streaming Devices Found!',
                         'dialog-information'
                         )
                     found.show()
@@ -430,7 +431,7 @@ class menubar(QtWidgets.QMainWindow):
             self.menu.clear()
             self.search_menu()
             self.separator_menu()
-            print('Available Google Cast Devices', self.availablecc)
+            print('Available Media Streaming Devices', self.availablecc)
             for index, menuentry in enumerate(self.availablecc):
                 try:
                     self.a = self.ag.addAction((QtWidgets.QAction(str(menuentry[1]), self, checkable=True)))
@@ -697,7 +698,7 @@ class menubar(QtWidgets.QMainWindow):
             else:
                 self.sl.setValue(self.cast.volume)
         self.sl.valueChanged.connect(self.value_changed)
-        self.sl.setWindowTitle('Google Cast Volume')
+        self.sl.setWindowTitle('Device Volume')
         self.sl.show()
 
     def value_changed(self, value):
@@ -894,7 +895,7 @@ class menubar(QtWidgets.QMainWindow):
                 '-title',
                 'mkchromecast',
                 '-message',
-                'Searching for Google Cast Devices...'
+                'Searching for Media Streaming Devices...'
                 ]
             subprocess.Popen(searching)
             if debug == True:
@@ -907,7 +908,7 @@ class menubar(QtWidgets.QMainWindow):
                 Notify.init('mkchromecast')
                 found=Notify.Notification.new(
                     'mkchromecast',
-                    'Searching for Google Cast Devices...',
+                    'Searching for Media Streaming Devices...',
                     'dialog-information'
                     )
                 found.show()

--- a/mkchromecast/systray.py
+++ b/mkchromecast/systray.py
@@ -473,6 +473,7 @@ class menubar(QtWidgets.QMainWindow):
             self.pcastfailed = False
             if os.path.exists('/tmp/mkchromecast.tmp') == True:
                 self.cast = mkchromecast.tray_threading.cast
+
             if os.path.exists('images/'+self.google[self.colors]+'.icns') == True:
                 if platform == 'Darwin':
                     self.tray.setIcon(
@@ -598,28 +599,32 @@ class menubar(QtWidgets.QMainWindow):
             pass
 
         if self.cast != None or self.stopped == True or self.pcastfailed == True:
+
             try:
                 self.cast.quit_app()
             except AttributeError:
-                pass
+                self.cast.stop() # This is for sonos. The thing is that if we are at this point, user requested an stop or cast failed.
             self.reset_audio()
+
             try:
                 self.kill_child()
             except psutil.NoSuchProcess:
                 pass
             checkmktmp()
             self.search_cast()
+
             while True:     # This is to retry when stopping and pychromecast.error.NotConnected raises.
                 try:
                     self.cast.quit_app()
                 except pychromecast.error.NotConnected:
                     continue
                 except AttributeError:
-                    continue
+                    self.cast.stop() # This is for sonos. The thing is that if we are at this point, user requested an stop or cast failed.
                 break
 
             self.stopped = True
             self.read_config()
+
             if platform == 'Darwin' and self.notifications == 'enabled':
                 if self.pcastfailed == True:
                     stop = [

--- a/mkchromecast/systray.py
+++ b/mkchromecast/systray.py
@@ -676,42 +676,30 @@ class menubar(QtWidgets.QMainWindow):
                     print('If you want to receive notifications in Linux, install  libnotify and python-gobject')
 
     def volume_cast(self):
-        self.maxvolset = 40
         self.sl = QtWidgets.QSlider(Qt.Horizontal)
         self.sl.setMinimum(0)
-        self.sl.setMaximum(self.maxvolset)
-        self.sl.setGeometry(30*self.scale_factor, 40*self.scale_factor, 260*self.scale_factor, 70*self.scale_factor)
+        self.sl.setGeometry(
+                30 * self.scale_factor,
+                40 * self.scale_factor,
+               260 * self.scale_factor,
+                70 * self.scale_factor
+                )
         self.sl.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
         try:
+            self.maxvolset = 40
+            self.sl.setMaximum(self.maxvolset)
             self.sl.setValue(round((self.cast.status.volume_level*self.maxvolset), 1))
         except AttributeError:
+            self.maxvolset = 100
+            self.sl.setMaximum(self.maxvolset)
+            self.sl.setValue(self.cast.volume)
+        finally:
             self.sl.setValue(2)
-        self.sl.valueChanged.connect(self.valuechange)
+        self.sl.valueChanged.connect(self.value_changed)
         self.sl.setWindowTitle('Google Cast Volume')
         self.sl.show()
 
-        """
-        self.sl = QSlider(Qt.Horizontal, self)
-        self.sl.setMinimum(0)
-        self.sl.setMaximum(10)
-        #self.sl.setFocusPolicy(Qt.NoFocus)
-        self.sl.setGeometry(30, 40, 180, 20)
-        try:
-            self.sl.setValue(round((self.cast.status.volume_level*10), 1))
-        except AttributeError:
-            self.sl.setValue(2)
-        self.sl.valueChanged.connect(self.valuechange)
-
-        #self.label = QLabel(self)
-        #self.label.setPixmap(QPixmap('images/max.png'))
-        #self.label.setGeometry(160, 40, 80, 30)
-
-        self.setGeometry(300, 300, 240, 100)
-        self.setWindowTitle('Google cast volume')
-        self.show()
-        """
-
-    def valuechange(self, value):
+    def value_changed(self, value):
         try:
             if round(self.cast.status.volume_level, 1) == 1:
                 print (colors.warning(':::systray::: Maximum volume level reached!'))
@@ -723,7 +711,21 @@ class menubar(QtWidgets.QMainWindow):
             if debug == True:
                 print(':::systray::: Volume set to: '+str(volume))
         except AttributeError:
-            pass
+            """
+            Sonos volume
+            """
+            self.maxvolset = 100
+            if (self.cast.volume) == 100:
+                print (colors.warning(':::systray::: Maximum volume level reached!'))
+                volume = value
+                self.cast.volume = volume
+                self.cast.play()
+            else:
+                volume = value
+                self.cast.volume = volume
+                self.cast.play()
+            if debug == True:
+                print(':::systray::: Volume set to: '+str(volume))
         if debug == True:
             print(':::systray::: Volume changed: '+str(value))
 

--- a/mkchromecast/systray.py
+++ b/mkchromecast/systray.py
@@ -692,9 +692,10 @@ class menubar(QtWidgets.QMainWindow):
         except AttributeError:
             self.maxvolset = 100
             self.sl.setMaximum(self.maxvolset)
-            self.sl.setValue(self.cast.volume)
-        finally:
-            self.sl.setValue(2)
+            if self.played == False:
+                self.sl.setValue(2)
+            else:
+                self.sl.setValue(self.cast.volume)
         self.sl.valueChanged.connect(self.value_changed)
         self.sl.setWindowTitle('Google Cast Volume')
         self.sl.show()

--- a/mkchromecast/systray.py
+++ b/mkchromecast/systray.py
@@ -459,7 +459,10 @@ class menubar(QtWidgets.QMainWindow):
 
     def clicked_cc(self, clicked_item):
         if self.played == True:
-            self.cast.quit_app()
+            try:
+                self.cast.quit_app()
+            except AttributeError:
+                self.cast.stop()
 
         if debug == True:
             print(clicked_item)

--- a/mkchromecast/tray_threading.py
+++ b/mkchromecast/tray_threading.py
@@ -9,7 +9,7 @@ from mkchromecast.config import *
 import mkchromecast.audio
 from mkchromecast.node import *
 from mkchromecast.preferences import ConfigSectionMap
-from mkchromecast.pulseaudio import *
+from mkchromecast.pulseaudio import create_sink, check_sink
 from mkchromecast.systray import *
 from PyQt5.QtCore import QThread, QObject, pyqtSignal, pyqtSlot
 import os.path
@@ -85,7 +85,9 @@ class Player(QObject):
                 reload(mkchromecast.audio)
             mkchromecast.audio.main()
         if platform == 'Linux':
-            create_sink()
+            if check_sink() == False: # We create the sink only if it is not available
+                create_sink()
+
         start = casting()
         start.initialize_cast()
         try:

--- a/mkchromecast/tray_threading.py
+++ b/mkchromecast/tray_threading.py
@@ -11,7 +11,7 @@ from mkchromecast.node import *
 from mkchromecast.preferences import ConfigSectionMap
 from mkchromecast.pulseaudio import create_sink, check_sink
 from mkchromecast.systray import *
-from PyQt5.QtCore import QThread, QObject, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import (QThread, QObject, pyqtSignal, pyqtSlot)
 import os.path
 import pickle
 import pychromecast
@@ -85,7 +85,10 @@ class Player(QObject):
                 reload(mkchromecast.audio)
             mkchromecast.audio.main()
         if platform == 'Linux':
-            if check_sink() == False: # We create the sink only if it is not available
+            if check_sink() == False:   # We create the sink only if it is not available
+                create_sink()
+            else:                       # This is to fix a possible problem when letting the systray unused
+                remove_sink()           # for some time.
                 create_sink()
 
         start = casting()

--- a/mkchromecast/tray_threading.py
+++ b/mkchromecast/tray_threading.py
@@ -87,9 +87,6 @@ class Player(QObject):
         if platform == 'Linux':
             if check_sink() == False:   # We create the sink only if it is not available
                 create_sink()
-            else:                       # This is to fix a possible problem when letting the systray unused
-                remove_sink()           # for some time.
-                create_sink()
 
         start = casting()
         start.initialize_cast()

--- a/mkchromecast/tray_threading.py
+++ b/mkchromecast/tray_threading.py
@@ -45,9 +45,9 @@ class Worker(QObject):
         except socket.gaierror:
             if debug == True:
                 print(colors.warning(':::Threading::: Socket error, CC set to 0'))
-            self.cc.availablecc == 0
+            self.cc.availablecc = []
         except TypeError:
-            self.cc.availablecc == 0
+            self.cc.availablecc = []
         if len(self.cc.availablecc) == 0 and tray == True:
             availablecc = []
             self.intReady.emit(availablecc)

--- a/mkchromecast/tray_threading.py
+++ b/mkchromecast/tray_threading.py
@@ -45,9 +45,9 @@ class Worker(QObject):
         except socket.gaierror:
             if debug == True:
                 print(colors.warning(':::Threading::: Socket error, CC set to 0'))
-            self.cc.availablecc = []
+            pass
         except TypeError:
-            self.cc.availablecc = []
+            pass
         if len(self.cc.availablecc) == 0 and tray == True:
             availablecc = []
             self.intReady.emit(availablecc)


### PR DESCRIPTION
This is an attempt to add Sonos support.

- [x] Discover Sonos speakers. 
- [x] Select Sonos speaker.
- [x] Cast to Sonos speaker. 
- [x] Control Sonos speaker (volume). 
- [x] Systray support.
- [x] Support codecs different from `mp3`. 
- [ ] ~~Add support to different available flags. ~~ Moved to `devel`.
- [ ] ~~Add Equalizer in the controls. ~~ Moved to `devel`.
- [x] Reboot.

Adding support for sonos is very easy. Just install the `soco` module by:

```
 pip install soco
```

That's it. Note that at this stage, most of the options may still be broken. Systray is partially working, and only `mp3` codec is supported. If you find a problem, please do not hesitate to report it. 

If  you have both chromecasts and sonos speakers, use the `-s` flag to choose from the list :). 

