### PR TITLE
Fixed propper signal handling instead of input

### DIFF
--- a/mkchromecast.py
+++ b/mkchromecast.py
@@ -13,6 +13,8 @@ import subprocess
 import os.path
 import time
 import atexit
+import signal
+
 
 class mk(object):
     """Class to manage cast process"""
@@ -239,10 +241,11 @@ class mk(object):
             print('')
             print(colors.error('Ctrl-C to kill the Application at any Time'))
             print('')
-            try:
-                input()
-            except KeyboardInterrupt:
-                atexit.register(self.terminate_app())
+            signal.signal(signal.SIGINT,
+                          lambda *_: atexit.register(self.terminate_app()))
+            signal.signal(signal.SIGTERM,
+                          lambda *_: atexit.register(self.terminate_app()))
+            signal.pause()
 
     def backend_handler(self, action, backend):
         """Methods to handle pause and resume state of backends"""


### PR DESCRIPTION
The current signal handling is hard to work with if you want to fork the process into the background, as input() will get an EOF error. Reworked the current handling with the `signal` module.

A little unsure how this will work on OSX and Windows as i don't have anything to test with.

Signed-off-by: Morten Linderud <morten@linderud.pw>