### PR TITLE
adding audio to screencasting and ubuntu LTS support

### DIFF
--- a/mkchromecast.py
+++ b/mkchromecast.py
@@ -129,6 +129,12 @@ class mk(object):
 
     def cast_video(self):
         """This method launches video casting"""
+
+        print('Creating Pulseaudio Sink...')
+        print(colors.warning('Open Pavucontrol and Select the '
+              'Mkchromecast Sink.'))
+        create_sink()
+
         print(colors.important('Starting Video Cast Process...'))
         import mkchromecast.video
         mkchromecast.video.main()
@@ -174,7 +180,7 @@ class mk(object):
         if self.platform == 'Darwin':
             inputint()
             outputint()
-        elif self.platform == 'Linux' and self.adevice is None:
+        elif self.platform == 'Linux':
             remove_sink()
         terminate()
 

--- a/mkchromecast/systray.py
+++ b/mkchromecast/systray.py
@@ -463,12 +463,12 @@ class menubar(QtWidgets.QMainWindow):
             print('Available Media Streaming Devices', self.availablecc)
             for index, menuentry in enumerate(self.availablecc):
                 try:
-                    self.a = self.ag.addAction(
+                    a = self.ag.addAction(
                             (QtWidgets.QAction(
                                 str(menuentry[1]), self, checkable=True)))
                     self.menuentry = self.menu.addAction(self.a)
                 except UnicodeEncodeError:
-                    self.menuentry = self.menu.addAction(str(
+                    a = self.menuentry = self.menu.addAction(str(
                         unicode(menuentry[1]).encode("utf-8")))
                 # The receiver is a lambda function that passes clicked as
                 # a boolean, and the clicked_item as an argument to the
@@ -478,7 +478,7 @@ class menubar(QtWidgets.QMainWindow):
                 #
                 # http://stackoverflow.com/questions/1464548/pyqt-qmenu-dynamically-populated-and-clicked
                 receiver = lambda clicked, clicked_item=menuentry: self.clicked_cc(clicked_item)
-                self.a.triggered.connect(receiver)
+                a.triggered.connect(receiver)
             self.separator_menu()
             self.stop_menu()
             self.volume_menu()

--- a/mkchromecast/video.py
+++ b/mkchromecast/video.py
@@ -85,7 +85,6 @@ elif screencast is True:
             '-g', '60',  # '-c:a', 'copy', '-ac', '2',
             # '-b', '900k',
             '-f', 'mp4',
-            '-max_muxing_queue_size', '9999',
             '-movflags', 'frag_keyframe+empty_moov',
             'pipe:1'
             ]
@@ -104,7 +103,6 @@ else:
             '-map_chapters', '-1',
             '-preset', 'ultrafast',
             '-f', 'mp4',
-            '-max_muxing_queue_size', '9999',
             '-movflags', 'frag_keyframe+empty_moov',
             'pipe:1'
          ]
@@ -125,7 +123,6 @@ else:
             '-g', '60',  # '-c:a', 'copy', '-ac', '2',
             # '-b', '900k',
             '-f', 'mp4',
-            '-max_muxing_queue_size', '9999',
             '-movflags', 'frag_keyframe+empty_moov',
             'pipe:1'
         ]
@@ -139,7 +136,6 @@ else:
             '-map_chapters', '-1',
             '-preset', 'ultrafast',
             '-f', 'mp4',
-            '-max_muxing_queue_size', '9999',
             '-movflags', 'frag_keyframe+empty_moov',
             '-vf', 'subtitles='+subtitles,
             'pipe:1'
@@ -161,7 +157,6 @@ else:
             '-g', '60',  # '-c:a', 'copy', '-ac', '2',
             # '-b', '900k',
             '-f', 'mp4',
-            '-max_muxing_queue_size', '9999',
             '-movflags', 'frag_keyframe+empty_moov',
             '-vf', 'subtitles='+subtitles,
             'pipe:1'

--- a/mkchromecast/video.py
+++ b/mkchromecast/video.py
@@ -72,6 +72,15 @@ elif screencast is True:
         screen_size = resolution(res, screencast)
     command = [
             'ffmpeg',
+
+            '-ac', '2',
+            '-ar', '44100',
+            '-frame_size', '2048',
+            '-fragment_size', '2048',
+            '-f', 'pulse',
+            '-ac', '2',
+            '-i', 'Mkchromecast.monitor',
+
             '-f', 'x11grab',
             '-r', '25',
             '-s', screen_size,
@@ -86,6 +95,10 @@ elif screencast is True:
             # '-b', '900k',
             '-f', 'mp4',
             '-movflags', 'frag_keyframe+empty_moov',
+
+            '-ar', '44100',
+            '-acodec', 'libvorbis',
+
             'pipe:1'
             ]
     mtype = 'video/mp4'

--- a/mkchromecast/video.py
+++ b/mkchromecast/video.py
@@ -82,7 +82,6 @@ elif screencast is True:
         screen_size = resolution(res, screencast)
     command = [
             'ffmpeg',
-
             '-ac', '2',
             '-ar', '44100',
             '-frame_size', '2048',
@@ -104,10 +103,8 @@ elif screencast is True:
             # '-b', '900k',
             '-f', 'mp4',
             '-movflags', 'frag_keyframe+empty_moov',
-
             '-ar', '44100',
             '-acodec', 'libvorbis',
-
             'pipe:1'
             ]
 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ setuptools==36.6.0
 requests==2.18.4
 mutagen==1.38
 psutil==5.4.0
-PyQt5==5.9
+PyQt5
 gi==1.2


### PR DESCRIPTION
I've done three changes to adapt mkchromecast to my needs:
- Modified how pyqt is used to accomodate pyqt 5.5, which is what comes in Ubuntu 17.04 LTS
- Removed the -max_muxing_queue_size ffmpeg flag because it's not supported in ffmpeg 2.8.11 (the one I have in Ubuntu 17.04 LTS)
- Most importantly, added initial hacky support for screencasting with audio (pulseaudio) in Linux

Regarding this last point of audio&video, I remark it's been done in a hacky way because I'm asuming it's always done with pulseaudio and Linux. But just doing what @muammar suggested in https://github.com/muammar/mkchromecast/issues/104#issuecomment-357790035 didn't work for me because I wanted a monitor sink to be created. 

Anyway, this is just my way of sharing something that works, I don't expect this to be merged as-is.