### PR TITLE
master: Add linux support to setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *.DS_Store
 *.pyc
+*.pc
+*.egg-info
+build
+dist
+install

--- a/bin/mkchromecast
+++ b/bin/mkchromecast
@@ -1,6 +1,12 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # This file is part of mkchromecast.
+import os.path
+import sys
+
+HERE = os.path.dirname(__file__)
+if os.path.exists(os.path.join(HERE, '..', 'mkchromecast')):
+    sys.path.insert(0, os.path.join(HERE, '..'))
 
 import mkchromecast.__init__
 from mkchromecast.version import __version__
@@ -10,7 +16,6 @@ import mkchromecast.colors as colors
 from mkchromecast.pulseaudio import create_sink, remove_sink
 from mkchromecast.utils import terminate
 import subprocess
-import os.path
 import time
 import atexit
 import signal

--- a/mkchromecast.1
+++ b/mkchromecast.1
@@ -1,0 +1,52 @@
+.\"                                      Hey, EMACS: -*- nroff -*-
+.\" (C) Copyright 2017 Muammar El Khatib <muammar@debian.org>,
+.\"
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH Mkchromecast "1" "December 23 2017"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+mkchromecast \- cast audio and video to Google cast devices
+.SH SYNOPSIS
+.B mkchromecast
+.RI [ options ]
+.SH DESCRIPTION
+This manual page documents briefly the
+.B mkchromecast
+commands.
+.PP
+.\" TeX users may be more comfortable with the \fB<whatever>\fP and
+.\" \fI<whatever>\fP escape sequences to invode bold face and italics,
+.\" respectively.
+\fBmkchromecast\fP is a program that allows you to cast your audio or video
+files to your Google cast or Sonos devices.
+.SH OPTIONS
+This program follows the usual GNU command line syntax, with long
+options starting with two dashes (`-').
+A summary of options is included below.
+For a complete description, see the Info files.
+.TP
+.B \-h, \-\-help
+Show summary of options.
+.TP
+.B \-v, \-\-version
+Show version of program.
+.SH SEE ALSO
+.\".BR bar (1),
+.\".BR baz (1).
+.\".br
+The program is documented fully executing
+.IR "mkchromecast -h" ,
+that should give you complete access to the usage.

--- a/setup.py
+++ b/setup.py
@@ -3,21 +3,61 @@
 # This file is part of mkchromecast.
 
 """
-py2app build script for mkchromecast
+Linux/MacOS build script for mkchromecast
 
-Usage:
+
+MacOS usage:
     python3 setup.py py2app
-    cp -R /usr/local/Cellar/qt5/5.6.0/plugins dist/mkchromecast.app/Contents/PlugIns
+    cp -R /usr/local/Cellar/qt5/5.6.0/plugins \
+        dist/mkchromecast.app/Contents/PlugIns
     macdeployqt dist/mkchromecast.app
 
-You need to install using pip3 the following:
+On MacOS you need to install using pip3 the following:
 
     bs4
     google
+
+On Linux, this is a standard distutils script supporting
+
+   python3 setup.py build
+   python3 setup.py install
+
+etc., with standard setup.py options. Note that there are some non-python
+dependencies not listed here; see README.md.
 """
+import os
+import platform
+
+from glob import glob
 from setuptools import setup
 
-version=open('mkchromecast/version.py').readlines()[-1].split()[-1].strip("\"'")
+ROOT = os.path.dirname(__file__)
+ROOT = ROOT if ROOT else '.'
+
+VERSION = \
+    open('mkchromecast/version.py').readlines()[-1].split()[-1].strip("\"'")
+
+LINUX_DATA = [
+    ('share/mkchromecast/nodejs', glob('nodejs/*')),
+    ('share/mkchromecast/images', glob('images/google*.png')),
+    ('share/applications/', ['mkchromecast.desktop']),
+    ('share/man/man1', ['mkchromecast.1']),
+]
+LINUX_REQUIRES = [
+    'flask',
+    'mutagen',
+    'netifaces',
+    'psutil',
+    'PyChromecast',
+    'PyQt5',
+    'requests'
+]
+LINUX_CLASSIFIERS = [
+    'Development Status :: 4 - Beta',
+    'Intended Audience :: End Users/Desktop',
+    'License :: OSI Approved :: MIT License',
+    'Programming Language :: Python :: 3.6',
+]
 
 APP = ['start_tray.py']
 APP_NAME = 'Mkchromecast'
@@ -57,20 +97,40 @@ OPTIONS = {
         'CFBundleDisplayName': APP_NAME,
         'CFBundleGetInfoString': 'Cast macOS audio to your Google cast devices and Sonos speakers',
         'CFBundleIdentifier': 'com.mkchromecast.osx',
-        'CFBundleVersion': version,
-        'CFBundleShortVersionString': version,
+        'CFBundleVersion': VERSION,
+        'CFBundleShortVersionString': VERSION,
         'NSHumanReadableCopyright': u'Copyright (c) 2017, Muammar El Khatib, All Rights Reserved',
         'LSPrefersPPC': True,
         'LSUIElement': True
     }
 }
 
-setup(
-    name=APP_NAME,
-    app=APP,
-    data_files=DATA_FILES,
-    package='Mkchromecast',
-    platforms=['i386', 'x86_64'],
-    options={'py2app': OPTIONS},
-    setup_requires=['py2app'],
-)
+if platform.system() == 'Darwin':
+    setup(
+        name=APP_NAME,
+        app=APP,
+        data_files=DATA_FILES,
+        package='Mkchromecast',
+        platforms=['i386', 'x86_64'],
+        options={'py2app': OPTIONS},
+        setup_requires=['py2app'],
+    )
+
+elif platform.system() == 'Linux':
+    setup(
+        name='mkchromecast',
+        version=VERSION,
+        description='Cast Linux audio or video to Google Cast devices',
+        long_description=open(ROOT + '/README.md').read(),
+        include_package_data=True,
+        license='MIT',
+        url='http://mkchromecast.com/',
+        author='Muammar El Khatib',
+        author_email='http://muammar.me/',
+        keywords=['chromecast'],
+        packages=['mkchromecast'],
+        scripts=['bin/mkchromecast'],
+        classifiers=LINUX_CLASSIFIERS,
+        data_files=LINUX_DATA,
+        requires=LINUX_REQUIRES
+    )

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ DATA_FILES = [
         'images/google_working_w.icns',
         'images/google_nodev_w.icns',
         'bin/audiodevice',
+        'bin/mkchromecast',
         'nodejs',
         'notifier'
         ]


### PR DESCRIPTION
This PR is the underpinnings in master for #170 and #172. Basically, it makes mkchromecast to a complete pypi package on the Linux side, installable using pip3 and related tools. This simplifies things for both packagers and users on platforms without a native package.  

If/when this PR is accepted,  #170 and #172 need to be rebased to the new master before being merged, but that is a later issue. Basically, this PR is first part of #172. 

The PR contains untested changes with respect to MacOS builds. So, please verify this before merging!