### PR TITLE
setup.py: Drop nodejs stuff (#176).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ ROOT = os.path.dirname(__file__)
 ROOT = ROOT if ROOT else '.'
 
 LINUX_DATA = [
-    ('share/mkchromecast/nodejs', glob('nodejs/*')),
     ('share/mkchromecast/images', glob('images/google*.png')),
     ('share/applications/', ['mkchromecast.desktop']),
     ('share/man/man1', ['mkchromecast.1']),


### PR DESCRIPTION
The nodejs stuff is not part of any packaging, and should not
be part of the pypi stuff either.

This fixes the immediate problems with the pypi package, but
the underlying question in #176 remains the same: Why is it needed
at all in the first place?