### PR TITLE
Bind Flask to visible IP address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build
 dist
 install
+.idea

--- a/mkchromecast/audio.py
+++ b/mkchromecast/audio.py
@@ -6,6 +6,7 @@ Google Cast device has to point out to http://ip:5000/stream
 """
 
 import mkchromecast.__init__
+from mkchromecast import utils
 from mkchromecast.audio_devices import inputint, outputint
 from mkchromecast.config import config_manager
 import mkchromecast.colors as colors
@@ -41,8 +42,11 @@ tray = mkchromecast.__init__.tray
 adevice = mkchromecast.__init__.adevice
 chunk_size = mkchromecast.__init__.chunk_size
 segment_time = mkchromecast.__init__.segment_time
+host = mkchromecast.__init__.host
 port = mkchromecast.__init__.port
 platform = mkchromecast.__init__.platform
+
+ip = utils.get_effective_ip(platform, host_override=host, fallback_ip='0.0.0.0')
 
 frame_size = 32 * chunk_size
 buffer_size = 2 * chunk_size**2
@@ -785,7 +789,7 @@ def start_app():
     """
     monitor_daemon = monitor()
     monitor_daemon.start()
-    app.run(host='0.0.0.0', port=port, passthrough_errors=False)
+    app.run(host=ip, port=port, passthrough_errors=False)
 
 
 class multi_proc(object):       # I launch ffmpeg in a different process

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -2,6 +2,8 @@
 # This file is part of mkchromecast.
 
 from __future__ import print_function
+
+from mkchromecast import utils
 from mkchromecast.audio_devices import inputint, outputint
 import mkchromecast.colors as colors
 from mkchromecast.__init__ import args
@@ -61,58 +63,14 @@ class casting(object):
         self.ccname = mkchromecast.__init__.ccname
         self.hijack = mkchromecast.__init__.hijack
         self.tries = mkchromecast.__init__.tries
-        self.port = mkchromecast.__init__.port
-        self.port = str(self.port)
+        self.port = str(mkchromecast.__init__.port)
         self.title = 'Mkchromecast v' + mkchromecast.__init__.__version__
 
+        self.ip = self.host
         if self.host is None:
-            if self.platform == 'Linux':
-                self.getnetworkip()
-                try:
-                    self.ip = self.discovered_ip
-                except AttributeError:
-                    self.ip = '127.0.0.1'
-            else:
-                try:
-                    self.ip = socket.gethostbyname(socket.gethostname())
-                    if self.debug is True:
-                        print(':::cast::: sockets method', self.ip)
-                except socket.gaierror:
-                    self.netifaces_ip()
-                    try:
-                        self.ip = self.discovered_ip
-                    except AttributeError:
-                        self.ip = '127.0.0.1'
+            self.ip = utils.get_resolved_ip(self.platform)
         else:
             self.ip = self.host
-
-    """
-    Methods to discover local IP
-    """
-    def getnetworkip(self):
-        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-        try:
-            s.connect(("8.8.8.8", 80))
-        except socket.error:
-            self.ip = '127.0.0.1'
-        self.discovered_ip = s.getsockname()[0]
-        if self.debug is True:
-            print(':::cast::: sockets method', self.discovered_ip)
-
-    def netifaces_ip(self):
-        import netifaces
-        interfaces = netifaces.interfaces()
-        for interface in interfaces:
-            if interface == 'lo':
-                continue
-            iface = netifaces.ifaddresses(interface).get(netifaces.AF_INET)
-            if iface is not None and iface[0]['addr'] is not '127.0.0.1':
-                for e in iface:
-                    self.discovered_ip = str(e['addr'])
-                    if self.debug is True:
-                        print(':::cast::: netifaces method',
-                              self.discovered_ip)
 
     def _get_chromecasts(self):
         # compatibility

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -66,11 +66,7 @@ class casting(object):
         self.port = str(mkchromecast.__init__.port)
         self.title = 'Mkchromecast v' + mkchromecast.__init__.__version__
 
-        self.ip = self.host
-        if self.host is None:
-            self.ip = utils.get_resolved_ip(self.platform)
-        else:
-            self.ip = self.host
+        self.ip = utils.get_effective_ip(self.platform, host_override=self.host)
 
     def _get_chromecasts(self):
         # compatibility

--- a/mkchromecast/utils.py
+++ b/mkchromecast/utils.py
@@ -105,13 +105,20 @@ def check_file_info(name, what=None):
         return bit_depth
 
 
-def resolve_ip(platform):
+def get_effective_ip(platform, host_override=None, fallback_ip='127.0.0.1'):
+    if host_override is None:
+        return resolve_ip(platform, fallback_ip=fallback_ip)
+    else:
+        return host_override
+
+
+def resolve_ip(platform, fallback_ip):
     if platform == 'Linux':
         resolved_ip = _resolve_ip_linux()
     else:
         resolved_ip = _resolve_ip_nonlinux()
     if resolved_ip is None:
-        resolved_ip = '127.0.0.1'
+        resolved_ip = fallback_ip
     return resolved_ip
 
 

--- a/mkchromecast/utils.py
+++ b/mkchromecast/utils.py
@@ -7,6 +7,7 @@ from os import getpid
 import os.path
 import mkchromecast.colors as colors
 import subprocess
+import socket
 import json
 
 try:
@@ -102,3 +103,42 @@ def check_file_info(name, what=None):
     if what == 'bit-depth':
         bit_depth = d['streams'][0]['pix_fmt']
         return bit_depth
+
+
+def resolve_ip(platform):
+    if platform == 'Linux':
+        resolved_ip = _resolve_ip_linux()
+    else:
+        resolved_ip = _resolve_ip_nonlinux()
+    if resolved_ip is None:
+        resolved_ip = '127.0.0.1'
+    return resolved_ip
+
+
+def _resolve_ip_linux():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    try:
+        s.connect(("8.8.8.8", 80))
+    except socket.error:
+        return None
+    return s.getsockname()[0]
+
+
+def _resolve_ip_nonlinux():
+    try:
+        return socket.gethostbyname(socket.gethostname())
+    except socket.gaierror:
+        return _get_first_network_ip_by_netifaces()
+
+
+def _get_first_network_ip_by_netifaces():
+    import netifaces
+    interfaces = netifaces.interfaces()
+    for interface in interfaces:
+        if interface == 'lo':
+            continue
+        iface = netifaces.ifaddresses(interface).get(netifaces.AF_INET)
+        if iface is not None and iface[0]['addr'] is not '127.0.0.1':
+            for e in iface:
+                return str(e['addr'])

--- a/mkchromecast/video.py
+++ b/mkchromecast/video.py
@@ -6,6 +6,7 @@ Google Cast device has to point out to http://ip:5000/stream
 """
 
 import mkchromecast.__init__
+from mkchromecast import utils
 from mkchromecast.audio_devices import inputint, outputint
 import mkchromecast.colors as colors
 from mkchromecast.utils import terminate, is_installed, check_file_info
@@ -37,9 +38,12 @@ debug = mkchromecast.__init__.debug
 sourceurl = mkchromecast.__init__.sourceurl
 encoder_backend = mkchromecast.__init__.backend
 screencast = mkchromecast.__init__.screencast
+host = mkchromecast.__init__.host
 port = mkchromecast.__init__.port
 loop = mkchromecast.__init__.loop
 mtype = mkchromecast.__init__.mtype
+
+ip = utils.get_effective_ip(platform, host_override=host, fallback_ip='0.0.0.0')
 
 try:
     if input_file[-3:] == 'mkv':
@@ -282,7 +286,7 @@ def stream():
 def start_app():
     monitor_daemon = monitor()
     monitor_daemon.start()
-    app.run(host='0.0.0.0', port=port, threaded=True)
+    app.run(host=ip, port=port, threaded=True)
 
 
 class multi_proc(object):       # I launch ffmpeg in a different process


### PR DESCRIPTION
Originally thought to fix #199, but now I don't believe it is the proper fix.
Still, it might be worth merging in the name of code cleanup?

The Flask app now listens on the externally available/resolved IP address of the host instead of `0.0.0.0`. This is the same address as the `Local IP`, either set by `--host` on command line or auto-detected.