### PR TITLE
Better error message when Node input file is omitted

### DIFF
--- a/mkchromecast/video.py
+++ b/mkchromecast/video.py
@@ -423,6 +423,12 @@ def main():
                             input_file
                             ]
                         break
+
+        if input_file == None:
+            print(colors.warning('Please specify an input file with -i'))
+            print(colors.warning('Closing the application...'))
+            terminate()
+
         try:
             Popen(webcast)
         except:


### PR DESCRIPTION
Previously, the error message would be about Node missing
from the system because Popen fails. We therefore check
for a missing `input_file` before trying Popen.