### PR TITLE
add support for custom video codecs in ffmpeg

### DIFF
--- a/mkchromecast/__init__.py
+++ b/mkchromecast/__init__.py
@@ -526,6 +526,15 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "--vcodec",
+    type=str,
+    default="libx264",
+    help="""
+    Set a custom vcodec for ffmpeg when capturing screen.  Defaults to libx264
+    """
+)
+
+parser.add_argument(
     "--video",
     action="store_true",
     default=False,
@@ -702,6 +711,7 @@ Check that encoders exist in the list
 """
 screencast = args.screencast
 display = args.display
+vcodec = args.vcodec
 
 backends = ["node", "ffmpeg", "avconv"]
 if platform == "Darwin":

--- a/mkchromecast/video.py
+++ b/mkchromecast/video.py
@@ -38,6 +38,7 @@ source_url = mkchromecast.__init__.source_url
 encoder_backend = mkchromecast.__init__.backend
 screencast = mkchromecast.__init__.screencast
 display = mkchromecast.__init__.display
+vcodec = mkchromecast.__init__.vcodec
 host = mkchromecast.__init__.host
 port = mkchromecast.__init__.port
 loop = mkchromecast.__init__.loop
@@ -104,9 +105,12 @@ elif screencast is True:
         "-i",
         "{}.0+0,0".format(display),
         "-vcodec",
-        "libx264",
-        "-preset",
-        "veryfast",
+        vcodec
+    ]
+    if vcodec != "h264_nvenc":
+        command.append("-preset")
+        command.append("veryfast")
+    command.extend([
         "-tune",
         "zerolatency",
         "-maxrate",
@@ -127,7 +131,7 @@ elif screencast is True:
         "-acodec",
         "libvorbis",
         "pipe:1",
-    ]
+    ])
 else:
     """
     The blocks shown below are related to input_files


### PR DESCRIPTION
Sorry for the pull request spam.  I prefer using h264_nvenc for encoding because of performance on my machine.  This patch adds a --vcodec option defaulting to libx264 which changes the vcodec used by ffmpeg when casting the screen.  I also had to remove the preset flag from the ffmpeg command when this is set to h264_nvenc.  I don't have an AMD card to test their hardware encoding, so there may be compatibility issues there that I was unable to test for.  Hopefully someone will open an issue if they encounter any.