### PR TITLE
Fixing filenames with spaces

### DIFF
--- a/mkchromecast/__init__.py
+++ b/mkchromecast/__init__.py
@@ -11,6 +11,7 @@ import subprocess
 import os
 import os.path
 from argparse import RawTextHelpFormatter
+import shlex
 
 parser = argparse.ArgumentParser(
     description="""
@@ -785,7 +786,7 @@ Command
 """
 if args.command is not None and args.video is True:
     safe_commands = ["ffmpeg", "avconv", "youtube-dl"]
-    command = args.command.split(" ")
+    command = shlex.split(args.command)
     if command[0] not in safe_commands:
         print(colors.error("Refusing to execute this."))
         sys.exit(0)


### PR DESCRIPTION
Previously, this did not work, due to a space in the file name, regardless of quoting or nested quotes:

mkchromecast --video --command "ffmpeg -re -i 'test file.mp4' -map_chapters -1 -vcodec libx264 -preset ultrafast -tune zerolatency -maxrate 10000k -bufsize 20000k -pix_fmt yuv420p -g 60 -f mp4 -max_muxing_queue_size 9999 -movflags         frag_keyframe+empty_moov pipe:1"