### PR TITLE
Fixed the issue with subtitles not syncing when used along with the --seek option

### DIFF
--- a/mkchromecast/video.py
+++ b/mkchromecast/video.py
@@ -167,6 +167,17 @@ else:
     elif input_file is not None and subtitles is not None and mkv is False:
         # Command taken from
         # https://trac.ffmpeg.org/wiki/EncodingForStreamingSites#Streamingafile
+        if seek is not None:
+            fixsubs = [
+                'ffmpeg',
+                '-y',
+                '-i', subtitles,
+                '-ss', seek,
+                '/tmp/fixedsubs.srt'
+                ]
+            Popen(fixsubs).communicate()
+            subtitles="/tmp/fixedsubs.srt"
+
         command = [
             'ffmpeg',
             '-re',


### PR DESCRIPTION
ffmpeg now generates a temporary file with subtitles adjusted to the '--seek' option time.