### PR TITLE
Avoid removing unrelated PulseAudio null sinks.

### DIFF
--- a/mkchromecast/pulseaudio.py
+++ b/mkchromecast/pulseaudio.py
@@ -3,8 +3,12 @@
 import subprocess
 import time
 
+_sink_num = None
+
 
 def create_sink():
+    global _sink_num
+
     sink_name = "Mkchromecast"
 
     create_sink = ["pactl", "load-module", "module-null-sink", "sink_name=" + sink_name]
@@ -18,6 +22,7 @@ def create_sink():
 
     cs = subprocess.Popen(create_sink, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     csoutput, cserror = cs.communicate()
+    _sink_num = csoutput[:-1]
 
     time.sleep(1)
 
@@ -27,7 +32,10 @@ def create_sink():
 
 
 def remove_sink():
-    remove_sink = ["pactl", "unload-module", "module-null-sink"]
+    if _sink_num is None:
+        return
+
+    remove_sink = ["pactl", "unload-module", _sink_num]
 
     rms = subprocess.Popen(remove_sink, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     rmsoutput, rmserror = rms.communicate()


### PR DESCRIPTION
The current implementation of `remove_sink()` removes all `module-null-sink`s, whether or not they were installed by Mkchromecast, which can cause problems if null sinks are being used for other purposes. This PR changes the behavior to remember the id of the sink created and removes just that one.