### PR TITLE
Set sink description in load-module command.

### DIFF
--- a/mkchromecast/pulseaudio.py
+++ b/mkchromecast/pulseaudio.py
@@ -7,22 +7,11 @@ import time
 def create_sink():
     sink_name = "Mkchromecast"
 
-    create_sink = ["pactl", "load-module", "module-null-sink", "sink_name=" + sink_name]
-
-    rename_sink = [
-        "pacmd",
-        "update-sink-proplist",
-        sink_name,
-        "device.description=" + sink_name,
-    ]
+    create_sink = ["pactl", "load-module", "module-null-sink", "sink_name=" + sink_name, "sink_properties=device.description=" + sink_name]
 
     cs = subprocess.Popen(create_sink, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     csoutput, cserror = cs.communicate()
 
-    time.sleep(1)
-
-    rs = subprocess.Popen(rename_sink, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    rsoutput, rserror = rs.communicate()
     return
 
 


### PR DESCRIPTION
Avoid the extra `pacmd` call by setting the sink description in the initial `pactl` command.