### PR TITLE
Partially make pychromecast v7.2.0 compatible

### DIFF
--- a/mkchromecast/__init__.py
+++ b/mkchromecast/__init__.py
@@ -663,8 +663,9 @@ if args.reset is True:
         inputint()
         outputint()
     else:
-        from mkchromecast.pulseaudio import remove_sink
+        from mkchromecast.pulseaudio import remove_sink, get_sink_list
 
+        get_sink_list()
         remove_sink()
     terminate()
 

--- a/mkchromecast/systray.py
+++ b/mkchromecast/systray.py
@@ -29,7 +29,6 @@ We verify that pychromecast is installed
 """
 try:
     import pychromecast
-    from pychromecast.dial import reboot
 
     chromecast = True
 except ImportError:
@@ -657,6 +656,15 @@ class menubar(QtWidgets.QMainWindow):
             remove_sink()
 
     def reboot(self):
+
+        try:
+            from pychromecast.dial import reboot
+        except ImportError:
+            # reboot is removed from pychromecast.dial since PR394
+            # see: https://github.com/home-assistant-libs/pychromecast/pull/394
+            print(colors.warning("This version of pychromecast does not support reboot. Will do nothing."))
+            reboot = lambda x: None
+
         if platform == "Darwin":
             try:
                 self.cast.host_ = socket.gethostbyname(self.cast_to + ".local")


### PR DESCRIPTION
My Linux distribution is now providing `pychromecast 7.1.1` and higher. So I made some changes to make `mkchromecast` works with my setting.

### Coverage

1. I only have one Google Home Mini, so I didn't look into video and YouTube streaming. Only checked the audio casting.
2. I don't use the systray. So not sure if the systray works.
3. Tested with both `pychromecast 7.2.0` and `7.1.0`. Didn't go back further.
4. Tested with Python 3.8.

### Changes

Because my use case is very limited, these are small changes. But still, hope this can help some users.

1. improving `--reset` by adding `get_sink_list` and modifying `remove_sink`:
  If `mkchromecast` crashed due to some reasons, sometimes the sinks it created were still there. Running with `--reset` would not kill those residual sinks because `mkchromecast.pulseaudio._sink_num` is `None` in this situation. So I added `get_sink_list` to get related sinks and remove them.

2. adding dummy `reboot` to replace `pychromecast.dial.reboot` when it does not exist:
  Since home-assistant-libs/pychromecast#394, `pychromecast.dial.reboot` does not exist anymore. It seems there's currently no alternative way to reboot a device. But just in case rebooting reappears in the future, I didn't modify the existing code in `mkchromecast`. I simply added a dummy `reboot` that is doing nothing.

3. replacing `Chromacast.host` with `Chromecast.socket_client.host`:
  home-assistant-libs/pychromecast#395 removed the `host` and `port` attributes under `Chromecast` objects. But `Chromecast.socket_client.host` has been a valid attribute since `pychromecast v3.0.0`. Also, see home-assistant-libs/pychromecast#381 and home-assistant-libs/pychromecast#385.

4. fix the return of `pychromecast.get_chromecasts()`:
  home-assistant-libs/pychromecast#380 changed the output of `pychromecast.get_chromecasts` to a tuple. I believe this is the cause of issue #322 .