### PR TITLE
Support symlinking to the main binary

### DIFF
--- a/bin/mkchromecast
+++ b/bin/mkchromecast
@@ -4,7 +4,7 @@
 import os.path
 import sys
 
-HERE = os.path.dirname(__file__)
+HERE = os.path.dirname(os.path.realpath(__file__))
 if os.path.exists(os.path.join(HERE, '..', 'mkchromecast')):
     sys.path.insert(0, os.path.join(HERE, '..'))
 


### PR DESCRIPTION
On linux, it is common to symlink from a location already within the path (e..g /usr/bin) to the actual binary. This breaks mkchromecast's import scheme. By wrapping __file__ in a real path call, we can make the system work with symlinks like this without changing anything else (e.g. it works as expected all other times)