### PR TITLE
Explicitly add getch subpackage to the manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include mkchromecast/getch/*.py


### PR DESCRIPTION
When run outside of a Git checkout, setuptools somehow fails to find the `mkchromecast.getch` subpackage and install it, resulting in broken functionality.

I’m not sure why exactly this is necessary. I found out about this accidentally when a user complained the control functionality was broken in the latest Debian package. I checked it locally and it worked, and then I found out the packages built at buildds were missing these files. I rebuilt locally again and everything went fine. I the ran `apt source` elsewhere and built there — and the files were missing.
