### PR TITLE
Fix deprecation warnings due to invalid escape sequences.

### DIFF
--- a/mkchromecast/__init__.py
+++ b/mkchromecast/__init__.py
@@ -539,7 +539,7 @@ parser.add_argument(
     "--video",
     action="store_true",
     default=False,
-    help="""
+    help=r"""
     Use this flag to cast video to your Google cast devices. It is only working
     with ffmpeg.
 


### PR DESCRIPTION
Fixes deprecation warning by using raw string 

```
find . -iname '*.py' | xargs -P4 -I{} python3.8 -Wall -m py_compile {}   
./mkchromecast/__init__.py:542: DeprecationWarning: invalid escape sequence \?
  help="""
```