### PR TITLE
Fix regex used to parse sink list

### DIFF
--- a/mkchromecast/pulseaudio.py
+++ b/mkchromecast/pulseaudio.py
@@ -88,8 +88,8 @@ def get_sink_list():
     )
 
     pattern = re.compile(
-        r"\s*?index:\s*?\d+\s*$\s*?name:\s*?<Mkchromecast.*>"
-        + r"\s*?$(?:\n^.*?$)*?\n^\s*?module: (?P<module>\d+?)\s*?$",
+        r"^Sink\s*#\d+\s*$(?:\n^.*?$)*?\n\s*?Name:\s*?Mkchromecast.*"
+        + r"\s*?$(?:\n^.*?$)*?\n^\s*?Owner Module: (?P<module>\d+?)\s*?$",
         re.MULTILINE,
     )
     matches = pattern.findall(result.stdout.decode("utf-8"), re.MULTILINE)


### PR DESCRIPTION
The reset subcommand was failing to clean up left over sinks, as the
output of `pactl list sinks` is considerably different to the output of
`pacmd list sinks`.