### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3
+
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y \
+      ffmpeg \
+      libgirepository1.0-dev \
+      pulseaudio-utils \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/
+
+RUN pip install --no-cache youtube-dl
+
+WORKDIR /usr/src/mkchromecast/
+
+COPY requirements.txt .
+RUN pip install --no-cache -r requirements.txt
+
+COPY . .
+RUN pip install --no-cache .
+
+ENTRYPOINT [ "mkchromecast" ]


### PR DESCRIPTION
Builds OK, but needs more work to make it run.
It needs access (as far as I can tell):
* Host's PulseAudio server
* Host's ALSA device
* X11 server

Manually mounting everything is cumbersome, so I've tried with [x11docker](https://github.com/mviereck/x11docker):
``` console
$ x11docker --xpra --network=host --hostdbus --alsa --ipc --pulseaudio mkchromecast
x11docker WARNING: User amontero is member of group docker.
  That allows unprivileged processes on host to gain root privileges.

x11docker note: Option --xpra: If you encounter issues with xpra,
  you can try --nxagent instead.
  Rather use xpra from www.xpra.org than from distribution repositories.

x11docker WARNING: Option --ipc=host severely degrades
  container isolation. IPC namespace remapping is disabled.

x11docker WARNING: Option --network=host severely degrades
  container isolation. Network namespacing is disabled.
  Container shares host network stack.
  Spying on network traffic may be possible.
  Access to host X server :0 may be possible
  through abstract unix socket.

x11docker WARNING: Option --pulseaudio allows container applications
  to catch your audio output and microphone input.

x11docker WARNING: Option --alsa: ALSA sound degrades container isolation.
  Sharing device files in /dev/snd, container gains access to sound hardware.
  Container applications can catch audio output and microphone input.

x11docker note: Option --alsa: It seems that pulseaudio is running
  on your host. Pulseaudio can interfere with ALSA sound.
  Host sound may not work while container is playing sound and vice versa.
  Alternative: with pulseaudio on host and in image, use option --pulseaudio.

x11docker WARNING: --hostdbus: Connecting container to host DBus degrades
  container isolation. Container applications might send malicious requests.

x11docker WARNING: Sharing device file: /dev/snd

Mkchromecast v0.3.9
Creating Pulseaudio Sink...
Open Pavucontrol and Select the Mkchromecast Sink.
Starting Local Streaming Server
[Done]
Selected backend: parec
Selected audio codec: mp3
Default bitrate used: 192k
Default sample rate used: 44100Hz.
 * Serving Flask app 'mkchromecast.audio' (lazy loading)
PID of main process: 115
PID of streaming process: 118
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
 * Running on http://192.168.1.100:5000 (Press CTRL+C to quit)
Killed
/usr/bin/x11docker línia 925: 19684 Terminat                { waitforlogentry xpra $Storeinfofile "xinitrc=ready" infinity; rocknroll && start_xpra; }
/usr/bin/x11docker línia 925: 18488 Terminat                watchmessagefifo
```