### PR TITLE
Tells mypy to check untyped defs.

### DIFF
--- a/test.py
+++ b/test.py
@@ -45,7 +45,11 @@ class MkchromecastTests(unittest.TestCase):
             self.skipTest("mypy not installed")
 
         mypy_cmd = [
-            "mypy", "--ignore-missing-imports", "--no-namespace-packages"]
+            "mypy",
+            "--ignore-missing-imports",
+            "--no-namespace-packages",
+            "--check-untyped-defs"
+        ]
 
         mypy_result = subprocess.run(
             mypy_cmd + self.type_targets,


### PR DESCRIPTION
In particular, this is important to have mypy highlight type errors from parts
of the codebase that haven't yet been annotated with types, but that might
already be misusing types that have been annotated.