### PR TITLE
Creates the beginnings of a unit test suite, and runs those unit tests when `test.py` is run

### DIFF
--- a/mkchromecast/__init__.py
+++ b/mkchromecast/__init__.py
@@ -15,12 +15,8 @@ import shlex
 class _Mkchromecast:
     """An object that encapsulates Mkchromecast state."""
 
-    def __init__(self):
-        # TODO(xsdg): Args parsing should happen outside of this class, and the
-        # parsed args should be passed in.
-        self.args = _arg_parsing.Parser.parse_args()
-        args = self.args  # Shorthand, since it's used frequently below.
-
+    def __init__(self, args):
+        self.args = args
         self.debug: bool = args.debug
 
         # Arguments with no dependencies.
@@ -245,9 +241,14 @@ class Mkchromecast:
     """A singleton object that encapsulates Mkchromecast state."""
     _instance: Optional[_Mkchromecast] = None
 
-    def __new__(cls):
+    def __new__(cls, args = None):
         if cls._instance is None:
-            cls._instance = _Mkchromecast()
+            if not args:
+                # TODO(xsdg): Args parsing should only ever happen outside of
+                # this class.
+                args = _arg_parsing.Parser.parse_args()
+
+            cls._instance = _Mkchromecast(args)
 
         return cls._instance
 

--- a/mkchromecast/_arg_parsing.py
+++ b/mkchromecast/_arg_parsing.py
@@ -500,7 +500,6 @@ Parser.add_argument(
 Parser.add_argument(
     "--update",
     type=invalid_arg("Argument dropped."),
-    action="store_true",
     help="Do not use.  Argument dropped.",
 )
 

--- a/test.py
+++ b/test.py
@@ -14,6 +14,10 @@ import unittest
 
 import pychromecast
 
+
+# Modify this to enable debug logging of test outputs.
+ENABLE_DEBUG_LOGGING = False
+
 # This argument parser will steal arguments from unittest.  So we only define
 # arguments that are needed for the integration test, and that won't collide
 # with arguments that unittest cares about (like --help).
@@ -117,8 +121,8 @@ class MkchromecastTests(unittest.TestCase):
         if pytest_result.returncode:
             self.fail(pytest_result.stdout)
         else:
-            # Debug-log for diagnostic purposes.
-            logging.debug(pytest_result.stdout)
+            # Always show unit test output, even when they pass.
+            logging.info("\n" + pytest_result.stdout)
 
     # "ZZ" prefix so this runs last.
     def testZZEndToEndIntegration(self):
@@ -155,6 +159,9 @@ class MkchromecastTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    loglevel = logging.INFO if not ENABLE_DEBUG_LOGGING else logging.DEBUG
+    logging.basicConfig(format="%(levelname)s:%(message)s", level=loglevel)
+
     # Steals known arguments from unittest in order to properly configure the
     # integration test.
     integration_args, skipped_argv = integration_arg_parser.parse_known_args()

--- a/test.py
+++ b/test.py
@@ -89,6 +89,22 @@ class MkchromecastTests(unittest.TestCase):
             # Debug-log for diagnostic purposes.
             logging.debug(pytype_result.stdout)
 
+    def testExecUnitTests(self):
+        """Runs the Mkchromecast unit test suite."""
+        pytest_cmd = ["python3", "-m", "unittest", "discover", "-s", "tests"]
+        pytest_result = subprocess.run(
+            pytest_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            encoding="utf8",
+        )
+
+        if pytest_result.returncode:
+            self.fail(pytest_result.stdout)
+        else:
+            # Debug-log for diagnostic purposes.
+            logging.debug(pytest_result.stdout)
+
     # "ZZ" prefix so this runs last.
     def testZZEndToEndIntegration(self):
         args = integration_args  # Shorthand.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# this file is part of mkchromecast.

--- a/tests/test_instantiate.py
+++ b/tests/test_instantiate.py
@@ -1,0 +1,26 @@
+# this file is part of mkchromecast.
+
+import unittest
+from unittest import mock
+
+import mkchromecast
+from mkchromecast import _arg_parsing
+
+class BasicInstantiationTest(unittest.TestCase):
+    def testInstantiate(self):
+        # TODO(xsdg): Do a better job of mocking the args parser.
+
+        mock_args = mock.Mock()
+        # Here we set the minimal required args for __init__ to not sys.exit.
+        mock_args.encoder_backend = None
+        mock_args.command = None
+        mock_args.resolution = None
+        mock_args.chunk_size = 64
+        mock_args.sample_rate = 44100
+        mock_args.youtube = None
+        mock_args.input_file = None
+        mkcc = mkchromecast.Mkchromecast(mock_args)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This was necessary to ensure that the new Mkchromecast class could be
instantiated.  But also, it paves the way for creating an actual suite of unit
tests as the broader refactor continues and more functionality is encapsulated
as classes.