### PR TITLE
Drops support for avconv, which is defunct.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This is a program to cast your **macOS** audio, or **Linux** audio to your
 Google Cast devices or Sonos speakers. It can also [cast video files](#video).
 
 It is written for Python3, and it can stream via `node.js`, `parec` (**Linux**),
-`ffmpeg`, or `avconv`.  **Mkchromecast** is capable of using lossy and lossless
-audio formats provided that `ffmpeg`, `avconv` (**Linux**), or `parec`
-(**Linux**) are installed. It also supports [Multi-room group
+or `ffmpeg`.  **Mkchromecast** is capable of using lossy and lossless audio
+formats provided that `ffmpeg` or `parec` (**Linux**) are installed. It also
+supports [Multi-room group
 playback](https://support.google.com/chromecast/answer/6329016?hl=en), and
  [24-bit/96kHz high audio resolution](https://github.com/muammar/mkchromecast#high-quality-audio).
 Additionally, a system tray menu is available.
@@ -33,8 +33,7 @@ degrade the sound quality. For more information visit the
 [wiki](https://github.com/muammar/mkchromecast/wiki/), and the
 [FAQ](https://github.com/muammar/mkchromecast/wiki/FAQ).
 
-You can optionally install `ffmpeg` or `avconv` (the latter only supported in **Linux**,
-[more information
+You can optionally install `ffmpeg` [more information
 here](https://github.com/muammar/mkchromecast#using-the-ffmpeg-backend-with-mkchromecast-installed-from-sources)).
 **Linux** users also can configure [ALSA to capture
 audio](https://github.com/muammar/mkchromecast/wiki/ALSA).  Note that sometimes
@@ -128,7 +127,6 @@ following:
 * flac.
 * faac.
 * ffmpeg (optional).
-* avconv (optional).
 * PyQt5 (optional if you want to use the system tray menu).
 * youtube-dl (option if you plan to cast youtube URLs or [supported
   websites](https://rg3.github.io/youtube-dl/supportedsites.html)).
@@ -152,7 +150,6 @@ requirements are:
 * flac.
 * faac.
 * ffmpeg.
-* avconv (optional).
 * PyQt5 (optional if you want to use the system tray menu).
 * youtube-dl (option if you plan to cast youtube URLs or [supported
   websites](https://rg3.github.io/youtube-dl/supportedsites.html)).
@@ -315,7 +312,7 @@ an issue in chromecast audio devices. See [this thread](https://goo.gl/yNVODZ).
 Therefore, if you want to go beyond `44100Hz` you have to [capture the sound at
 a higher sample rate](https://github.com/muammar/mkchromecast/wiki/Sample-rates).
 
-##### ffmpeg or avconv
+##### ffmpeg
 
 The easiest way of installing `ffmpeg` is using a package manager, *e.g.*: brew,
 macports or fink. Or in the case of **Linux**, *e.g.*: apt, yum, or pacman.
@@ -338,8 +335,6 @@ install `ffmpeg` with the following options enabled:
 brew install ffmpeg --with-fdk-aac --with-tools --with-freetype --with-libass --with-libvorbis --with-libvpx --with-x265 --with-opus
 ```
 
-**Mkchromecast** does not support `avconv` in **macOS**.
-
 ###### Linux
 
 As I use Debian, the way of installing `ffmpeg` is:
@@ -348,13 +343,7 @@ As I use Debian, the way of installing `ffmpeg` is:
 apt-get install ffmpeg
 ```
 
-or `avconv`
-
-```
-apt-get install libav-tools
-```
-
-**Audio coding formats available with `parec`, `ffmpeg` and `avconv` backends**
+**Audio coding formats available with `parec` and `ffmpeg` backends**
 
 **Audio coding format** | **Description**                   | **Notes**
 ------------------------| ----------------------------------|------------------
@@ -501,9 +490,6 @@ and another one to change the sampling rate:
 ```
 mkchromecast --encoder-backend ffmpeg -c ogg -b 128 --sample-rate 48000
 ```
-
-**Note**: to use `avconv` just replace from `ffmpeg` to `avconv` in the
-commands above.
 
 ##### Using **Mkchromecast** from the system tray
 

--- a/bin/mkchromecast
+++ b/bin/mkchromecast
@@ -50,22 +50,11 @@ class CastProcess(object):
 
         # Type declarations
         self.cc: Casting
-        self.backends: List[str]
 
     def run(self):
         self.cc = Casting(self.mkcc)
         checkmktmp()
         writePidFile()
-
-        """
-        Initializing backend array
-        """
-        self.backends = [
-          'ffmpeg',
-          'avconv',
-          'parec',
-          'gstreamer'
-          ]
 
         self.check_connection()
         if self.mkcc.tray is False and self.mkcc.videoarg is False:
@@ -182,10 +171,13 @@ class CastProcess(object):
             print(colors.error('Internal error: failed to select a backend.'))
             terminate()
 
-        if backend == 'node' and self.mkcc.source_url is None:
+        if self.mkcc.source_url:
+            return
+
+        if backend == 'node':
             from mkchromecast.node import stream
             stream()
-        elif backend in self.backends and self.mkcc.source_url is None:
+        else:
             import mkchromecast.audio
             mkchromecast.audio.main()
 

--- a/mkchromecast/__init__.py
+++ b/mkchromecast/__init__.py
@@ -62,13 +62,9 @@ class Mkchromecast:
         # Arguments that depend on other arguments.
         self.select_device: bool = True if self.tray else args.select_device
 
-        if self.platform == "Darwin":
-            backend_options = ["node", "ffmpeg"]
-        else:  # platform == "Linux"
-            if args.video:
-                backend_options = ["node", "ffmpeg", "avconv"]
-            else:
-                backend_options = ["ffmpeg", "avconv", "parec", "gstreamer"]
+        backend_options = constants.backend_options_for_platform(
+            self.platform, args.video
+        )
 
         self.backend: Optional[str]
         if args.encoder_backend:
@@ -111,7 +107,7 @@ class Mkchromecast:
             self.rcodec = None
 
         # TODO(xsdg): Add support for yt-dlp
-        command_choices = ["ffmpeg", "avconv", "youtube-dl"]
+        command_choices = ["ffmpeg", "youtube-dl"]
         self.command: Optional[str]
         if not args.command:
             self.command = None

--- a/mkchromecast/_arg_parsing.py
+++ b/mkchromecast/_arg_parsing.py
@@ -30,10 +30,9 @@ Parser = argparse.ArgumentParser(
     Cast devices.
 
     It is written in Python, and it can stream via node.js, ffmpeg, parec
-    (Linux pulseaudio users), avconv (Linux only) or ALSA (Linux users).
-    Mkchromecast is capable of using lossy and lossless audio formats provided
-    that ffmpeg, avconv or parec is installed.  Additionally, a system tray
-    menu is available.
+    (Linux pulseaudio users), or ALSA (Linux users). Mkchromecast is capable of
+    using lossy and lossless audio formats provided that ffmpeg or parec is
+    installed.  Additionally, a system tray menu is available.
 
     Linux users that have installed the debian package need to launch the
     command `mkchromecast`, e.g.:
@@ -69,9 +68,9 @@ Parser.add_argument(
     Example:
         python mkchromecast.py --encoder-backend ffmpeg --alsa-device hw:2,1
 
-    It only works for the ffmpeg and avconv backends, and it is not useful for
-    pulseaudio users. For more information read the README.Debian file shipped
-    in the Debian package or https://github.com/muammar/mkchromecast/wiki/ALSA.
+    It only works for the ffmpeg backend, and it is not useful for pulseaudio
+    users. For more information read the README.Debian file shipped in the
+    Debian package or https://github.com/muammar/mkchromecast/wiki/ALSA.
     """,
 )
 
@@ -103,18 +102,14 @@ Parser.add_argument(
     default="64",
     help="""
     Set the chunk size base for streaming in the Flask server. Default to 64.
-    This option only works when using the ffmpeg or avconv backends. This
-    number is the base to set both the buffer_size (defined by
-    2 * chunk_size**2) in Flask server and the frame_size (defined by 32
-      * chunk_size).
+    This option only works when using the ffmpeg backend. This number is the
+    base to set both the buffer_size (defined by 2 * chunk_size**2) in Flask
+    server and the frame_size (defined by 32 * chunk_size).
 
     Example:
 
     ffmpeg:
         python mkchromecast.py --encoder-backend ffmpeg -c ogg -b 128 --chunk-size 2048
-
-    avconv:
-        python mkchromecast.py --encoder-backend avconv -c ogg -b 128 --chunk-size 64
 
     """,
 )
@@ -137,7 +132,7 @@ Parser.add_argument(
         - wav  [HQ]     Waveform Audio File Format
         - flac [HQ]     Free Lossless Audio Codec
 
-    This option only works for the ffmpeg, avconv and parec backends.
+    This option only works for the ffmpeg and parec backends.
     """,
 )
 
@@ -146,7 +141,7 @@ Parser.add_argument(
     type=str,
     default=None,
     help="""
-    Set a ffmpeg or avconv command for streaming video.
+    Set an ffmpeg command for streaming video.
 
     Example:
         python3 mkchromecast.py --video --command 'ffmpeg -re -i \
@@ -156,7 +151,7 @@ Parser.add_argument(
         frag_keyframe+empty_moov pipe:1'
 
     Note that for the output you have to use pipe:1 to stream. This option only
-    works for the ffmpeg, avconv backends.
+    works for the ffmpeg backend.
     """,
 )
 
@@ -206,13 +201,13 @@ Parser.add_argument(
     "--encoder-backend",
     type=str,
     default=None,
+    choices=["ffmpeg", "gstreamer", "node", "parec"],
     help="""
     Set the backend for all encoders.
     Possible backends:
         - node (default in macOS)
         - parec (default in Linux)
         - ffmpeg
-        - avconv
         - gstreamer
 
     Example:

--- a/mkchromecast/audio.py
+++ b/mkchromecast/audio.py
@@ -108,8 +108,7 @@ else:
         bitrate = str(_mkcc.bitrate)
         samplerate = str(_mkcc.samplerate)
 
-    backends = ["ffmpeg", "avconv", "parec"]
-    if tray is True and backend in backends:
+    if tray and backend in ["ffmpeg", "parec"]:
         import os
         import getpass
 
@@ -752,8 +751,7 @@ else:
             if segment_time is not None:
                 set_segment_time(-11)
 
-    verbose_backend = ["ffmpeg", "avconv"]
-    if debug is False and backends_dict[backend] in verbose_backend:
+    if not debug and backends_dict[backend] == "ffmpeg":
         debug_command()
 
 app = Flask(__name__)

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -337,48 +337,31 @@ class Casting(object):
                     config.read(configf)
                     self.mkcc.backend = ConfigSectionMap("settings")["backend"]
 
-            if self.mkcc.source_url is not None:
-                if self.mkcc.videoarg is True:
-                    import mkchromecast.video
+            # Set up the mime type and conditionally import video or audio
+            # TODO(xsdg): Get rid of these conditional imports.
+            media_type: str
+            if self.mkcc.videoarg:
+                import mkchromecast.video
 
-                    mtype = mkchromecast.video.mtype
-                else:
-                    import mkchromecast.audio
+                media_type = mkchromecast.video.mtype
+            else:
+                import mkchromecast.audio
 
-                    mtype = mkchromecast.audio.mtype
-                print(" ")
-                print(
-                    colors.options("Casting from stream URL:") + " " + self.mkcc.source_url
-                )
-                print(colors.options("Using media type:") + " " + mtype)
-                media_controller.play_media(
-                    self.mkcc.source_url, mtype, title=self.title, stream_type="LIVE"
-                )
-                media_controller.play()
-            elif (
-                self.mkcc.backend == "ffmpeg"
-                or self.mkcc.backend == "node"
-                or self.mkcc.backend == "avconv"
-                or self.mkcc.backend == "parec"
-                or self.mkcc.backend == "gstreamer"
-                and self.mkcc.source_url is None
-            ):
-                if self.mkcc.videoarg is True:
-                    import mkchromecast.video
+                media_type = mkchromecast.audio.mtype
+            print(" ")
+            print(colors.options("Using media type:") + f" {media_type}")
 
-                    mtype = mkchromecast.video.mtype
-                else:
-                    import mkchromecast.audio
+            play_url: str
+            if self.mkcc.source_url:
+                play_url = self.mkcc.source_url
+                print(colors.options("Casting from stream URL:")
+                      + f" {play_url}")
+            else:
+                play_url = f"http://{localip}:{self.mkcc.port}/stream"
 
-                    mtype = mkchromecast.audio.mtype
-                print(" ")
-                print(colors.options("The media type string used is:") + " " + mtype)
-                media_controller.play_media(
-                    f"http://{localip}:{self.mkcc.port}/stream",
-                    mtype,
-                    title=self.title,
-                    stream_type="LIVE",
-                )
+            media_controller.play_media(
+                play_url, media_type, title=self.title, stream_type="LIVE",
+            )
 
             if media_controller.is_active:
                 media_controller.play()

--- a/mkchromecast/constants.py
+++ b/mkchromecast/constants.py
@@ -15,3 +15,17 @@ def sample_rates_for_codec(codec: str) -> List[int]:
         return MAX_48K_SAMPLE_RATES
 
     return ALL_SAMPLE_RATES
+
+
+DARWIN_BACKENDS = ["node", "ffmpeg"]
+LINUX_VIDEO_BACKENDS = ["node", "ffmpeg"]
+LINUX_BACKENDS = ["ffmpeg", "parec", "gstreamer"]
+
+def backend_options_for_platform(platform: str, video: bool = False):
+    if platform == "Darwin":
+        return DARWIN_BACKENDS
+
+    if video:
+        return LINUX_VIDEO_BACKENDS
+
+    return LINUX_BACKENDS

--- a/mkchromecast/preferences.py
+++ b/mkchromecast/preferences.py
@@ -99,30 +99,18 @@ if _mkcc.tray is True:
             """
             Backend
             """
-            backends_supported = ["node", "ffmpeg", "avconv", "parec", "gstreamer"]
-            self.backends = []
-            if _mkcc.platform == "Darwin":
-                for item in backends_supported:
-                    if (
-                        is_installed(item, PATH, _mkcc.debug) is True
-                        and item != "avconv"
-                        and item != "gstreamer"
-                    ):
-                        self.backends.append(item)
-            else:
-                for item in backends_supported:
-                    if (
-                        is_installed(item, PATH, _mkcc.debug) is True
-                        and item != "node"
-                        and item != "gstreamer"
-                    ):
-                        self.backends.append(item)
-                    # hardcoded gst-launch-1.0 for gstreamer
-                    elif (
-                        is_installed("gst-launch-1.0", PATH, _mkcc.debug) is True
-                        and item == "gstreamer"
-                    ):
-                        self.backends.append(item)
+            backend_options = constants.backend_options_for_platform(
+                _mkcc.platform
+            )
+            self.backends: List[str] = []
+            for option in backend_options:
+                if is_installed(option, PATH, _mkcc.debug):
+                    self.backends.append(option)
+            # Hard-coded for gstreamer.
+            if (_mkcc.platform == "Linux"
+                and is_installed("gst-launch-1.0", PATH, _mkcc.debug)):
+                self.backends.append("gstreamer")
+
             try:
                 backend_index = self.backends.index(self.backend_conf)
             except ValueError:

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -11,6 +11,21 @@ class ConstantsTests(unittest.TestCase):
         self.assertEqual(constants.ALL_SAMPLE_RATES,
                          constants.sample_rates_for_codec("aac"))
 
+    def testLinuxBackends(self):
+        """Ensures video argument is used correctly, with the right default."""
+        self.assertIn(
+            "parec",
+            constants.backend_options_for_platform("Linux", video=False)
+        )
+        self.assertNotIn(
+            "parec",
+            constants.backend_options_for_platform("Linux", video=True)
+        )
+        self.assertEqual(
+            constants.backend_options_for_platform("Linux"),
+            constants.backend_options_for_platform("Linux", video=False)
+        )
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
Also centralizes backend listing in constants.py, and simplifies code that shouldn't have an explicit dependency on backend names in the first place.

Note that this is untested with the node backend, which uses a lot of separate codepaths, so it wouldn't be surprising if this introduces unnoticed issues for node-based playback.