### PR TITLE
Uses bitrate as int throughout mkchromecast, and ensures that it is always non-None.

### DIFF
--- a/mkchromecast/__init__.py
+++ b/mkchromecast/__init__.py
@@ -134,16 +134,13 @@ class Mkchromecast:
                     print(f"- {resolution}")
                 sys.exit(0)
 
-        self.bitrate: Optional[int]
-        if self.codec in constants.BITRATE_CODECS:
+        self.bitrate: int
+        if self.codec in constants.CODECS_WITH_BITRATE:
             if args.bitrate <= 0:
                 print(colors.error("Bitrate must be a positive integer"))
                 sys.exit(0)
 
             self.bitrate = args.bitrate
-        else:
-            # When the codec doesn't require bitrate, we set it to None.
-            self.bitrate = None
 
         if args.chunk_size <= 0:
             print(colors.error("Chunk size must be a positive integer"))

--- a/mkchromecast/__init__.py
+++ b/mkchromecast/__init__.py
@@ -135,7 +135,7 @@ class Mkchromecast:
                 sys.exit(0)
 
         self.bitrate: Optional[int]
-        if self.codec in ["mp3", "ogg", "acc", "opus", "flac"]:
+        if self.codec in constants.BITRATE_CODECS:
             if args.bitrate <= 0:
                 print(colors.error("Bitrate must be a positive integer"))
                 sys.exit(0)

--- a/mkchromecast/__init__.py
+++ b/mkchromecast/__init__.py
@@ -141,6 +141,9 @@ class Mkchromecast:
                 sys.exit(0)
 
             self.bitrate = args.bitrate
+        else:
+            # Will be ignored downstream.
+            self.bitrate = constants.DEFAULT_BITRATE
 
         if args.chunk_size <= 0:
             print(colors.error("Chunk size must be a positive integer"))

--- a/mkchromecast/_arg_parsing.py
+++ b/mkchromecast/_arg_parsing.py
@@ -78,10 +78,10 @@ Parser.add_argument(
     "-b",
     "--bitrate",
     type=int,
-    default=None,
+    default=192,
     help="""
     Set the audio encoder's bitrate. The default is set to be 192k average
-    bitrate.
+    bitrate.  Will be ignored for lossless codecs like flac or wav.
 
     Example:
 

--- a/mkchromecast/_arg_parsing.py
+++ b/mkchromecast/_arg_parsing.py
@@ -78,7 +78,7 @@ Parser.add_argument(
     "-b",
     "--bitrate",
     type=int,
-    default="192",
+    default=None,
     help="""
     Set the audio encoder's bitrate. The default is set to be 192k average
     bitrate.

--- a/mkchromecast/config.py
+++ b/mkchromecast/config.py
@@ -123,13 +123,14 @@ class config_manager(object):
         searchatlaunch = ConfigSectionMap("settings")["searchatlaunch"]
         alsadevice = ConfigSectionMap("settings")["alsadevice"]
 
-        codecs = ["mp3", "ogg", "aac", "opus", "flac"]
-
         if os.path.exists(self.configf):
             """
             Reading the codec from config file
             """
-            if codec in codecs and bitrate == "None":
+            # Bitrate must always be set.  It will be ignored for lossless
+            # codecs like FLAC and WAV.
+            if bitrate == "None":
+                # TODO(xsdg): Only update a single field instead of all of them?
                 self.config.set("settings", "backend", str(backend))
                 self.config.set("settings", "codec", str(codec))
                 self.config.set("settings", "bitrate", "192")

--- a/mkchromecast/constants.py
+++ b/mkchromecast/constants.py
@@ -29,3 +29,7 @@ def backend_options_for_platform(platform: str, video: bool = False):
         return LINUX_VIDEO_BACKENDS
 
     return LINUX_BACKENDS
+
+
+DEFAULT_BITRATE = 192
+CODECS_WITH_BITRATE = ["aac", "mp3", "ogg", "opus"]

--- a/mkchromecast/messages.py
+++ b/mkchromecast/messages.py
@@ -6,24 +6,6 @@ from mkchromecast import colors
 from mkchromecast import constants
 
 
-def print_bitrate_warning(codec: str, bitrate: str) -> None:
-    print(colors.warning(
-        f"Maximum bitrate supported by {codec} is: {bitrate}k."
-        )
-    )
-
-    if codec == "aac":
-        print(colors.warning(
-            "128-256k is already considered sufficient for maximum quality "
-            f"using {codec}."
-            )
-        )
-        print(colors.warning(
-            "Consider a lossless audio codec for higher quality."
-            )
-        )
-
-
 def print_samplerate_warning(codec: str) -> None:
     """Prints a warning when sample rates are set incorrectly."""
     str_rates = [

--- a/mkchromecast/pipeline_builder.py
+++ b/mkchromecast/pipeline_builder.py
@@ -10,7 +10,7 @@ from mkchromecast import stream_infra
 class EncodeSettings:
     codec: str
     adevice: Optional[str]
-    bitrate: str
+    bitrate: int
     frame_size: int
     samplerate: str
     segment_time: Optional[int]
@@ -88,7 +88,7 @@ class Audio:
         )
 
         maybe_bitrate_cmd: list[str] = (
-            ["-b:a", self._settings.bitrate] if fmt != "wav" else []
+            ["-b:a", f"{self._settings.bitrate}k"] if fmt != "wav" else []
         )
 
         # TODO(xsdg): It's really weird that the legacy code excludes
@@ -131,13 +131,13 @@ class Audio:
         if self._settings.codec == "mp3":
             # NOTE(xsdg): Apparently lame wants "192" and not "192k"
             return ["lame",
-                    "-b", self._settings.bitrate[:-1],
+                    "-b", str(self._settings.bitrate),
                     "-r",
                     "-"]
 
         if self._settings.codec == "ogg":
             return ["oggenc",
-                    "-b", self._settings.bitrate[:-1],
+                    "-b", str(self._settings.bitrate),
                     "-Q",
                     "-r",
                     "--ignorelength",
@@ -149,7 +149,7 @@ class Audio:
             # the ffmpeg code which only applies it when segment_time is
             # included.  Figure out this discrepancy.
             return ["faac",
-                    "-b", self._settings.bitrate[:-1],
+                    "-b", str(self._settings.bitrate),
                     "-X",
                     "-P",
                     "-c", "18000",
@@ -160,7 +160,7 @@ class Audio:
             return ["opusenc",
                     "-",
                     "--raw",
-                    "--bitrate", self._settings.bitrate[:-1],
+                    "--bitrate", str(self._settings.bitrate),
                     "--raw-rate", self._settings.samplerate,
                     "-"]
 

--- a/mkchromecast/stream_infra.py
+++ b/mkchromecast/stream_infra.py
@@ -50,7 +50,7 @@ class FlaskServer:
     # Audio arguments.
     _adevice: Optional[str]
     _backend: BackendInfo
-    _bitrate: str
+    _bitrate: int
     _buffer_size: int
     _codec: str
     _platform: str
@@ -80,7 +80,7 @@ class FlaskServer:
     @staticmethod
     def init_audio(adevice: Optional[str],
                    backend: BackendInfo,
-                   bitrate: str,
+                   bitrate: int,
                    buffer_size: int,
                    codec: str,
                    command: Union[str, list[str]],

--- a/tests/test_pipeline_builder.py
+++ b/tests/test_pipeline_builder.py
@@ -67,12 +67,29 @@ class AudioBuilderTests(unittest.TestCase):
             self.create_builder("ffmpeg", "Darwin", ffmpeg_debug=False).command)
 
     def testBitrateSpecialCase(self):
+        # wav doesn't emit bitrate.
         self.assertIn(
             "-b:a",
             self.create_builder("ffmpeg", "Darwin", codec="mp3").command)
         self.assertNotIn(
             "-b:a",
             self.create_builder("ffmpeg", "Darwin", codec="wav").command)
+
+        # ffmpeg should use "k" suffix.
+        self.assertIn(
+            "160k",
+            self.create_builder("ffmpeg", "Linux", bitrate=160).command)
+        self.assertNotIn(
+            "160",
+            self.create_builder("ffmpeg", "Linux", bitrate=160).command)
+
+        # non-ffmpeg (parec in this case) should omit "k" suffix.
+        self.assertIn(
+            "160",
+            self.create_builder("parec", "Linux", bitrate=160).command)
+        self.assertNotIn(
+            "160k",
+            self.create_builder("parec", "Linux", bitrate=160).command)
 
     def testSegmentTimeSpecialCase(self):
         self.assertIn(
@@ -130,7 +147,7 @@ class AudioBuilderTests(unittest.TestCase):
             "-acodec", "libmp3lame",
             "-ac", "2",
             "-ar", "22050",
-            "-b:a", "160",
+            "-b:a", "160k",
             "pipe:",
         ]
 
@@ -149,7 +166,7 @@ class AudioBuilderTests(unittest.TestCase):
             "-acodec", "aac",
             "-ac", "2",
             "-ar", "22050",
-            "-b:a", "160",
+            "-b:a", "160k",
             "-cutoff", "18000",
             "pipe:",
         ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,56 @@
+# this file is part of mkchromecast.
+
+import unittest
+from unittest import mock
+
+from mkchromecast import utils
+
+class ClampBitrateTests(unittest.TestCase):
+    def setUp(self):
+        self.mock_print = self.enterContext(mock.patch("builtins.print", autospec=True))
+
+    def testMissingBitrate(self):
+        utils.clamp_bitrate("codec", None)
+
+        self.mock_print.assert_called_once()
+        print_str = self.mock_print.call_args.args[0]
+        self.assertNotIn("invalid", print_str)
+        self.assertIn("default", print_str)
+
+    def testInvalidBitrate(self):
+        for bitrate in -192, -1, 0:
+            with self.subTest(bitrate=bitrate):
+                self.mock_print.reset_mock()
+                utils.clamp_bitrate("codec", bitrate)
+
+                self.mock_print.assert_called_once()
+                print_str = self.mock_print.call_args.args[0]
+                self.assertIn("invalid", print_str)
+                self.assertIn("192", print_str)
+
+    def testNoClamp(self):
+        # Codecs other than mp3, ogg, or aac shouldn't have an upper bound.
+        cases = {"mp3": 320, "ogg": 500, "aac": 500, "opus": 1048576}
+        for codec, bitrate in cases.items():
+            with self.subTest(codec=codec):
+                self.mock_print.reset_mock()
+                self.assertEqual(bitrate, utils.clamp_bitrate(codec, bitrate))
+                self.mock_print.assert_not_called()
+
+    def testClamp(self):
+        cases = {"mp3": 321, "ogg": 501, "aac": 501}
+        for codec, bitrate in cases.items():
+            with self.subTest(codec=codec):
+                self.mock_print.reset_mock()
+                self.assertEqual(bitrate - 1,
+                                 utils.clamp_bitrate(codec, bitrate))
+
+                self.mock_print.assert_called_once()
+                print_str = self.mock_print.call_args.args[0]
+                self.assertIn(codec, print_str)
+                self.assertIn(str(bitrate), print_str)
+                self.assertIn(str(bitrate - 1), print_str)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This makes more progress on #434.