### PR TITLE
Creates a new "Operation Mode" enum that establishes the unique purpose of this mkchromecast invocation.

### DIFF
--- a/bin/mkchromecast
+++ b/bin/mkchromecast
@@ -89,7 +89,7 @@ class CastProcess(object):
         print(colors.important('Starting Local Streaming Server'))
         if self.mkcc.backend == 'node':
             import mkchromecast.node
-            mkchromecast.node.stream()
+            mkchromecast.node.stream_audio()
         else:
             import mkchromecast.audio
             mkchromecast.audio.main()

--- a/bin/mkchromecast
+++ b/bin/mkchromecast
@@ -80,7 +80,6 @@ class CastProcess(object):
                 f'Unsupported or unexpected operation: {self.mkcc.operation}')
 
     def start_audiocast(self):
-        # not youtube_url and not source_url
         if self.mkcc.platform == "Linux" and self.mkcc.adevice is None:
             print('Creating Pulseaudio Sink...')
             print(colors.warning(

--- a/bin/mkchromecast
+++ b/bin/mkchromecast
@@ -18,6 +18,7 @@ from mkchromecast.audio_devices import (inputint, inputdev, outputdev,
                                         outputint)
 from mkchromecast.cast import Casting
 import mkchromecast.colors as colors
+from mkchromecast.constants import OpMode
 from mkchromecast.pulseaudio import create_sink, get_sink_list, remove_sink
 from mkchromecast.utils import terminate, checkmktmp, writePidFile
 from mkchromecast.messages import print_available_devices
@@ -26,7 +27,7 @@ from mkchromecast.messages import print_available_devices
 def maybe_execute_single_action(mkcc: mkchromecast.Mkchromecast):
     """Potentially executes a one-off action, followed by exiting."""
 
-    if mkcc.reset:
+    if mkcc.operation == OpMode.RESET:
         # TODO(xsdg): unify the various entry and cleanup codepaths.
         if mkcc.platform == "Darwin":
             inputint()
@@ -37,7 +38,7 @@ def maybe_execute_single_action(mkcc: mkchromecast.Mkchromecast):
         terminate()
         sys.exit(0)
 
-    if mkcc.version:
+    if mkcc.operation == OpMode.VERSION:
         print("mkchromecast " + "v" + colors.success(__version__))
         sys.exit(0)
 
@@ -60,84 +61,66 @@ class CastProcess(object):
         atexit.register(self.terminate_app)
 
         self.check_connection()
-        if self.mkcc.tray is False and self.mkcc.videoarg is False:
-            if self.mkcc.platform == 'Linux':
-                self.audio_linux()
-            else:
-                self.audio_macOS()
-        elif self.mkcc.tray is False and self.mkcc.videoarg is True:
+        if self.mkcc.operation == OpMode.DISCOVER:
+            # TODO(xsdg): Move this to maybe_execute_single_action.
+            self.cc.initialize_cast()
+            terminate()
+        elif self.mkcc.operation == OpMode.AUDIOCAST:
+            self.start_audiocast()
+        elif self.mkcc.operation == OpMode.SOURCE_URL:
+            self.start_source_url()
+        elif self.mkcc.operation == OpMode.YOUTUBE:
+            self.start_youtube()
+        elif self.mkcc.operation == OpMode.TRAY:
+            self.start_tray()
+        elif self.mkcc.operation in {OpMode.INPUT_FILE, OpMode.SCREENCAST}:
             self.cast_video()
         else:
-            self.start_tray()
+            raise Exception(
+                f'Unsupported or unexpected operation: {self.mkcc.operation}')
 
-    def audio_linux(self):
-        """This method manages all related to casting audio in Linux"""
-        if self.mkcc.youtube_url is None and self.mkcc.source_url is None:
-            if self.mkcc.adevice is None:
-                print('Creating Pulseaudio Sink...')
-                print(colors.warning('Open Pavucontrol and Select the '
-                      'Mkchromecast Sink.'))
-                create_sink()
-            print(colors.important('Starting Local Streaming Server'))
-            print(colors.success('[Done]'))
-            self.start_backend(self.mkcc.backend)
-            self.cc.initialize_cast()
-            self.get_devices(self.mkcc.select_device)
-            self.cc.play_cast()
-            self.block_until_exit()
+    def start_audiocast(self):
+        # not youtube_url and not source_url
+        if self.mkcc.platform == "Linux" and self.mkcc.adevice is None:
+            print('Creating Pulseaudio Sink...')
+            print(colors.warning(
+                'Open Pavucontrol and Select the Mkchromecast Sink.'))
+            create_sink()
 
-        elif self.mkcc.youtube_url is None and self.mkcc.source_url is not None:
-            self.start_backend(self.mkcc.backend)
-            self.cc.initialize_cast()
-            self.get_devices(self.mkcc.select_device)
-            self.cc.play_cast()
-            self.block_until_exit()
-
-        # When casting youtube url, we do it through the audio module
-        elif self.mkcc.youtube_url is not None and self.mkcc.videoarg is False:
+        print(colors.important('Starting Local Streaming Server'))
+        if self.mkcc.backend == 'node':
+            import mkchromecast.node
+            mkchromecast.node.stream()
+        else:
             import mkchromecast.audio
             mkchromecast.audio.main()
-            self.cc.initialize_cast()
-            self.get_devices(self.mkcc.select_device)
-            self.cc.play_cast()
-            self.block_until_exit()
+        print(colors.success('[Done]'))
 
-    def audio_macOS(self):
-        """This method manages all related to casting audio in macOS"""
-        if self.mkcc.youtube_url is None and self.mkcc.source_url is None:
-            self.start_backend(self.mkcc.backend)
-            self.cc.initialize_cast()
-            self.get_devices(self.mkcc.select_device)
+        self.cc.initialize_cast()
+        self.get_devices(self.mkcc.select_device)
 
+        if self.mkcc.platform == "Darwin":
             print('Switching to BlackHole...')
             inputdev()
             outputdev()
             print(colors.success('[Done]'))
-            self.cc.play_cast()
-            self.block_until_exit()
 
-        elif self.mkcc.youtube_url is None and self.mkcc.source_url is not None:
-            self.start_backend(self.mkcc.backend)
-            self.cc.initialize_cast()
-            self.get_devices(self.mkcc.select_device)
-            self.cc.play_cast()
-            self.block_until_exit()
+        self.cc.play_cast()
+        self.block_until_exit()
 
-            print('Switching to BlackHole...')
-            inputdev()
-            outputdev()
-            print(colors.success('[Done]'))
-            self.cc.play_cast()
-            self.block_until_exit()
+    def start_source_url(self):
+        self.cc.initialize_cast()
+        self.get_devices(self.mkcc.select_device)
+        self.cc.play_cast()
+        self.block_until_exit()
 
-        # When casting youtube url, we do it through the audio module
-        elif self.mkcc.youtube_url is not None and self.mkcc.videoarg is False:
-            import mkchromecast.audio
-            mkchromecast.audio.main()
-            self.cc.initialize_cast()
-            self.get_devices(self.mkcc.select_device)
-            self.cc.play_cast()
-            self.block_until_exit()
+    def start_youtube(self):
+        import mkchromecast.audio
+        mkchromecast.audio.main()
+        self.cc.initialize_cast()
+        self.get_devices(self.mkcc.select_device)
+        self.cc.play_cast()
+        self.block_until_exit()
 
     def cast_video(self):
         """This method launches video casting"""
@@ -168,31 +151,11 @@ class CastProcess(object):
         else:
             self.cc.get_devices()
 
-    def start_backend(self, backend: Optional[str]):
-        """Starting backends"""
-        if not backend:
-            print(colors.error('Internal error: failed to select a backend.'))
-            terminate()
-
-        if self.mkcc.source_url:
-            return
-
-        if backend == 'node':
-            from mkchromecast.node import stream
-            stream()
-        else:
-            import mkchromecast.audio
-            mkchromecast.audio.main()
-
     def check_connection(self):
         """Check if the computer is connected to a network"""
         if self.cc.ip == '127.0.0.1':        # We verify the local IP.
             print(colors.error('Your Computer is not Connected to Any '
                   'Network'))
-            terminate()
-        elif self.cc.ip != '127.0.0.1' and self.mkcc.discover is True:
-            # TODO(xsdg): Move this to maybe_execute_single_action.
-            self.cc.initialize_cast()
             terminate()
 
     def terminate_app(self):

--- a/mkchromecast/__init__.py
+++ b/mkchromecast/__init__.py
@@ -29,6 +29,27 @@ class Mkchromecast:
         self.args = args
         self.debug: bool = args.debug
 
+        # Operating Mode
+        self.operation: constants.OpMode
+        if args.discover:
+            self.operation = constants.OpMode.DISCOVER
+        elif args.input_file:
+            self.operation = constants.OpMode.INPUT_FILE
+        elif args.reset:
+            self.operation = constants.OpMode.RESET
+        elif args.screencast:
+            self.operation = constants.OpMode.SCREENCAST
+        elif args.source_url:
+            self.operation = constants.OpMode.SOURCE_URL
+        elif args.tray:
+            self.operation = constants.OpMode.TRAY
+        elif args.version:
+            self.operation = constants.OpMode.VERSION
+        elif args.youtube:
+            self.operation = constants.OpMode.YOUTUBE
+        else:
+            self.operation = constants.OpMode.AUDIOCAST
+
         # Arguments with no dependencies.
         # Groupings are mostly carried over from earlier code; unclear how
         # meaningful they are.

--- a/mkchromecast/__init__.py
+++ b/mkchromecast/__init__.py
@@ -3,6 +3,7 @@
 import mkchromecast.colors as colors
 from mkchromecast import _arg_parsing
 from mkchromecast import constants
+from mkchromecast.constants import OpMode
 from mkchromecast.utils import terminate, check_url
 from mkchromecast.version import __version__
 from mkchromecast.resolution import resolutions
@@ -30,25 +31,25 @@ class Mkchromecast:
         self.debug: bool = args.debug
 
         # Operating Mode
-        self.operation: constants.OpMode
+        self.operation: OpMode
         if args.discover:
-            self.operation = constants.OpMode.DISCOVER
+            self.operation = OpMode.DISCOVER
         elif args.input_file:
-            self.operation = constants.OpMode.INPUT_FILE
+            self.operation = OpMode.INPUT_FILE
         elif args.reset:
-            self.operation = constants.OpMode.RESET
+            self.operation = OpMode.RESET
         elif args.screencast:
-            self.operation = constants.OpMode.SCREENCAST
+            self.operation = OpMode.SCREENCAST
         elif args.source_url:
-            self.operation = constants.OpMode.SOURCE_URL
+            self.operation = OpMode.SOURCE_URL
         elif args.tray:
-            self.operation = constants.OpMode.TRAY
+            self.operation = OpMode.TRAY
         elif args.version:
-            self.operation = constants.OpMode.VERSION
+            self.operation = OpMode.VERSION
         elif args.youtube:
-            self.operation = constants.OpMode.YOUTUBE
+            self.operation = OpMode.YOUTUBE
         else:
-            self.operation = constants.OpMode.AUDIOCAST
+            self.operation = OpMode.AUDIOCAST
 
         # Arguments with no dependencies.
         # Groupings are mostly carried over from earlier code; unclear how
@@ -113,7 +114,7 @@ class Mkchromecast:
         self.codec: str
         self.rcodec: Optional[str]
 
-        if self.operation = OpMode.SOURCE_URL:
+        if self.operation == OpMode.SOURCE_URL:
             self.codec = args.codec
             self.rcodec = None
         elif self.backend == "node":

--- a/mkchromecast/__init__.py
+++ b/mkchromecast/__init__.py
@@ -113,7 +113,7 @@ class Mkchromecast:
         self.codec: str
         self.rcodec: Optional[str]
 
-        if self.source_url:
+        if self.operation = OpMode.SOURCE_URL:
             self.codec = args.codec
             self.rcodec = None
         elif self.backend == "node":

--- a/mkchromecast/_arg_parsing.py
+++ b/mkchromecast/_arg_parsing.py
@@ -523,6 +523,8 @@ Parser.add_argument(
     """,
 )
 
+# TODO(xsdg): Probably best to replace this with --suppress-video.  Otherwise,
+# we should either auto-detect audio-only usecases, or always send video.
 Parser.add_argument(
     "--video",
     action="store_true",

--- a/mkchromecast/audio.py
+++ b/mkchromecast/audio.py
@@ -47,7 +47,6 @@ if debug is True:
         ":::audio::: chunk_size, frame_size, buffer_size: %s, %s, %s"
         % (_mkcc.chunk_size, frame_size, buffer_size)
     )
-source_url = _mkcc.source_url
 config = ConfigParser.RawConfigParser()
 configurations = config_manager()  # Class from mkchromecast.config
 configf = configurations.configf
@@ -150,27 +149,23 @@ else:
     else:
         media_type = f"audio/{encode_settings.codec}"
 
-    if source_url is None:
-        print(colors.options("Selected backend:") + f" {backend}")
-        print(colors.options("Selected audio codec:")
-              + f" {encode_settings.codec}")
+    print(colors.options("Selected backend:") + f" {backend}")
+    print(colors.options("Selected audio codec:") + f" {encode_settings.codec}")
 
     if backend.name != "node":
         encode_settings.bitrate = utils.clamp_bitrate(encode_settings.codec,
                                                       encode_settings.bitrate)
 
-        if encode_settings.bitrate != "None" and not source_url:
+        if encode_settings.bitrate != "None":
             print(colors.options("Using bitrate:") + f" {encode_settings.bitrate}")
 
         if encode_settings.codec in constants.QUANTIZED_SAMPLE_RATE_CODECS:
             encode_settings.samplerate = str(utils.quantize_sample_rate(
-                bool(_mkcc.source_url),
                 encode_settings.codec,
                 int(encode_settings.samplerate))
             )
 
-        if source_url is None:
-            print(colors.options("Using sample rate:") + f" {encode_settings.samplerate}Hz")
+        print(colors.options("Using sample rate:") + f" {encode_settings.samplerate}Hz")
 
     builder = pipeline_builder.Audio(backend, platform, encode_settings)
     command = builder.command

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -13,6 +13,7 @@ import mkchromecast
 from mkchromecast import utils
 from mkchromecast.audio_devices import inputint, outputint
 import mkchromecast.colors as colors
+from mkchromecast.constants import OpMode
 from mkchromecast.preferences import ConfigSectionMap
 from mkchromecast.utils import terminate, checkmktmp
 from mkchromecast.pulseaudio import remove_sink
@@ -358,7 +359,7 @@ class Casting(object):
             print(colors.options("Using media type:") + f" {media_type}")
 
             play_url: str
-            if self.mkcc.source_url:
+            if self.mkcc.operation = OpMode.SOURCE_URL:
                 play_url = self.mkcc.source_url
                 print(colors.options("Casting from stream URL:")
                       + f" {play_url}")
@@ -388,6 +389,7 @@ class Casting(object):
                 self.r.daemon = True
                 self.r.start()
 
+        # TODO(xsdg): This isn't an appropriate exception-handling strategy.
         except AttributeError:
             self.sonos = self.cast_to
             self.sonos.play_uri(

--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -125,7 +125,7 @@ class Casting(object):
             print(" ")
             print_available_devices(self.available_devices())
             print(" ")
-            if self.mkcc.discover is False:
+            if self.mkcc.operation != OpMode.DISCOVER:
                 print(colors.important("Casting to first device shown above!"))
                 print(colors.important("Select devices by using the -s flag."))
                 print(" ")
@@ -139,7 +139,7 @@ class Casting(object):
         elif (
             len(self.cclist) != 0
             and self.mkcc.select_device is True
-            and self.mkcc.tray is False
+            and self.mkcc.operation != OpMode.TRAY
             and self.mkcc.device_name is None
         ):
             if self.mkcc.debug is True:
@@ -163,7 +163,7 @@ class Casting(object):
                 )
                 print(" ")
 
-        elif len(self.cclist) != 0 and self.mkcc.select_device is True and self.mkcc.tray is True:
+        elif len(self.cclist) != 0 and self.mkcc.select_device and self.mkcc.operation == OpMode.TRAY:
             if self.mkcc.debug is True:
                 print(
                     "elif len(self.cclist) != 0 and self.mkcc.select_device == True"
@@ -185,7 +185,7 @@ class Casting(object):
                 )
                 print(" ")
 
-        elif len(self.cclist) == 0 and self.mkcc.tray is False:
+        elif len(self.cclist) == 0 and self.mkcc.operation != OpMode.TRAY:
             if self.mkcc.debug is True:
                 print("elif len(self.cclist) == 0 and self.mkcc.tray == False:")
             print(colors.error("No devices found!"))
@@ -197,7 +197,7 @@ class Casting(object):
             terminate()
             exit()
 
-        elif len(self.cclist) == 0 and self.mkcc.tray is True:
+        elif len(self.cclist) == 0 and self.mkcc.operation == OpMode.TRAY:
             print(colors.error(":::Tray::: No devices found!"))
             self.available_devices = []
 
@@ -231,6 +231,12 @@ class Casting(object):
             except IndexError:
                 checkmktmp()
                 self.tf = open("/tmp/mkchromecast.tmp", "wb")
+                # TODO(xsdg): The original code had what was likely a typo here,
+                # in that this called `self.select_device()`, which did not
+                # exist.  It likely was supposed to be `self.select_a_device()`,
+                # but it's better to just start over, here.
+                raise Exception(
+                    "Internal error: Never worked; needs to be fixed.")
                 self.mkcc.select_device()
                 continue
             break
@@ -275,7 +281,7 @@ class Casting(object):
                     remove_sink()
                 # In the case that the tray is used, we don't kill the
                 # application
-                if self.mkcc.tray is False:
+                if self.mkcc.operation != OpMode.TRAY:
                     print(colors.error("Finishing the application..."))
                     terminate()
                     exit()
@@ -327,7 +333,7 @@ class Casting(object):
         try:
             media_controller = self.cast.media_controller
 
-            if self.mkcc.tray is True:
+            if self.mkcc.operation == OpMode.TRAY:
                 config = ConfigParser.RawConfigParser()
                 # Class from mkchromecast.config
                 from mkchromecast.config import config_manager
@@ -335,7 +341,7 @@ class Casting(object):
                 configurations = config_manager()
                 configf = configurations.configf
 
-                if os.path.exists(configf) and self.mkcc.tray is True:
+                if os.path.exists(configf) and self.mkcc.operation == OpMode.TRAY:
                     print(self.mkcc.tray)
                     print(colors.warning("Configuration file exists"))
                     print(colors.warning("Using defaults set there"))
@@ -359,7 +365,7 @@ class Casting(object):
             print(colors.options("Using media type:") + f" {media_type}")
 
             play_url: str
-            if self.mkcc.operation = OpMode.SOURCE_URL:
+            if self.mkcc.operation == OpMode.SOURCE_URL:
                 play_url = self.mkcc.source_url
                 print(colors.options("Casting from stream URL:")
                       + f" {play_url}")
@@ -391,12 +397,15 @@ class Casting(object):
 
         # TODO(xsdg): This isn't an appropriate exception-handling strategy.
         except AttributeError:
+            raise Exception("Internal error: This code path is broken and "
+                            "needs to be fixed.")
             self.sonos = self.cast_to
             self.sonos.play_uri(
                 "x-rincon-mp3radio://" + localip + ":" + self.mkcc.port + "/stream",
                 title=self.title,
             )
-            if self.mkcc.tray is True:
+            if self.mkcc.operation == OpMode.TRAY:
+                # TODO(xsdg): No.
                 self.cast = self.sonos
 
     def pause(self):

--- a/mkchromecast/constants.py
+++ b/mkchromecast/constants.py
@@ -3,9 +3,10 @@
 import enum
 from typing import List
 
+
 @enum.unique
-class ActionMode(enum.Enum):
-    AUDIO = enum.auto()
+class OpMode(enum.Enum):
+    AUDIOCAST = enum.auto()
     DISCOVER = enum.auto()
     INPUT_FILE = enum.auto()
     RESET = enum.auto()
@@ -14,7 +15,6 @@ class ActionMode(enum.Enum):
     TRAY = enum.auto()
     VERSION = enum.auto()
     YOUTUBE = enum.auto()
-    VIDEO = enum.auto()
 
 
 # Formerly, "no96k", which was misleading because it implied that (for instance)

--- a/mkchromecast/constants.py
+++ b/mkchromecast/constants.py
@@ -1,6 +1,21 @@
 # This file is part of mkchromecast.
 
+import enum
 from typing import List
+
+@enum.unique
+class ActionMode(enum.Enum):
+    AUDIO = enum.auto()
+    DISCOVER = enum.auto()
+    INPUT_FILE = enum.auto()
+    RESET = enum.auto()
+    SCREENCAST = enum.auto()
+    SOURCE_URL = enum.auto()
+    TRAY = enum.auto()
+    VERSION = enum.auto()
+    YOUTUBE = enum.auto()
+    VIDEO = enum.auto()
+
 
 # Formerly, "no96k", which was misleading because it implied that (for instance)
 # 88200 was valid, which it is not.

--- a/mkchromecast/node.py
+++ b/mkchromecast/node.py
@@ -7,6 +7,9 @@ To call them:
     name()
 """
 
+# This file is audio-only for node.  Video via node is (currently) handled
+# completely within video.py.
+
 import configparser as ConfigParser
 import multiprocessing
 import os
@@ -25,6 +28,7 @@ from mkchromecast import constants
 from mkchromecast import utils
 from mkchromecast.cast import Casting
 from mkchromecast.config import config_manager
+from mkchromecast.constants import OpMode
 from mkchromecast.preferences import ConfigSectionMap
 
 
@@ -38,7 +42,7 @@ def streaming(mkcc: mkchromecast.Mkchromecast):
     configf = configurations.configf
 
     bitrate: int
-    if os.path.exists(configf) and mkcc.tray is True:
+    if os.path.exists(configf) and mkcc.operation == OpMode.TRAY:
         configurations.chk_config()
         print(colors.warning("Configuration file exists"))
         print(colors.warning("Using defaults set there"))
@@ -173,7 +177,7 @@ def streaming(mkcc: mkchromecast.Mkchromecast):
                     % (mkcc.platform, mkcc.tray, notifications)
                 )
 
-            if mkcc.platform == "Darwin" and mkcc.tray is True and notifications == "enabled":
+            if mkcc.platform == "Darwin" and mkcc.operation == OpMode.TRAY and notifications == "enabled":
                 reconnecting = [
                     "./notifier/terminal-notifier.app/Contents/MacOS/terminal-notifier",
                     "-group",
@@ -193,7 +197,12 @@ def streaming(mkcc: mkchromecast.Mkchromecast):
                     print(
                         ":::node::: reconnecting notifier command: %s." % reconnecting
                     )
-            relaunch(stream, recasting, kill)
+
+            # This could potentially cause forkbomb-like behavior where each new
+            # child process would create a new child process, ad infinitum.
+            raise Exception("Internal error: Never worked; needs to be fixed.")
+
+            relaunch(stream_audio, recasting, kill)
         return
 
 
@@ -229,6 +238,6 @@ def recasting():
     return
 
 
-def stream():
+def stream_audio():
     st = multi_proc()
     st.start()

--- a/mkchromecast/node.py
+++ b/mkchromecast/node.py
@@ -93,9 +93,7 @@ def streaming(mkcc: mkchromecast.Mkchromecast):
             print(colors.options("Using bitrate: ") + f"{bitrate}k.")
 
             if codec in constants.QUANTIZED_SAMPLE_RATE_CODECS:
-                samplerate = str(utils.quantize_sample_rate(
-                    bool(mkcc.source_url), codec, samplerate)
-                )
+                samplerate = str(utils.quantize_sample_rate(codec, samplerate))
 
             print(colors.options("Using sample rate:") + f" {samplerate}Hz.")
 

--- a/mkchromecast/pipeline_builder.py
+++ b/mkchromecast/pipeline_builder.py
@@ -10,6 +10,7 @@ from mkchromecast import constants
 from mkchromecast import resolution
 from mkchromecast import stream_infra
 from mkchromecast import utils
+from mkchromecast.constants import OpMode
 
 SubprocessCommand = Union[list[str], str, os.PathLike]
 
@@ -213,6 +214,7 @@ class VideoSettings:
     fps: str
     input_file: Optional[str]
     loop: bool
+    operation: OpMode
     resolution: Optional[str]
     screencast: bool
     seek: Optional[str]
@@ -237,22 +239,21 @@ class Video:
 
     @property
     def command(self) -> SubprocessCommand:
-        # TODO(xsdg): Set up a mutually-exclusive group for youtube_url,
-        # screencast, user_command, and input_file in _arg_parsing.py .
-        if self._settings.youtube_url:
+        if self._settings.operation == OpMode.YOUTUBE:
             return ["youtube-dl", "-o", "-", self._settings.youtube_url]
 
-        if self._settings.screencast:
+        if self._settings.operation == OpMode.SCREENCAST:
             return self._screencast_command()
 
         if self._settings.user_command:
             return self._settings.user_command
 
-        if self._settings.input_file:
+        if self._settings.operation == OpMode.INPUT_FILE:
             return self._input_file_command()
 
         # TODO(xsdg): Figure out if there's any way to actually get here.
-        raise Exception("Internal error: Unexpected video mode")
+        raise Exception("Internal error: Unexpected video operation mode "
+                        f"{self._settings.operation}")
 
     def _screencast_command(self) -> list[str]:
         screen_size = resolution.resolution(

--- a/mkchromecast/preferences.py
+++ b/mkchromecast/preferences.py
@@ -9,6 +9,7 @@ import webbrowser
 import mkchromecast
 from mkchromecast import constants
 from mkchromecast.config import config_manager
+from mkchromecast.constants import OpMode
 from mkchromecast.utils import is_installed
 
 """
@@ -55,7 +56,7 @@ def ConfigSectionMap(section):
     return dict1
 
 
-if _mkcc.tray is True:
+if _mkcc.operation == OpMode.TRAY:
     from PyQt5.QtWidgets import (
         QWidget,
         QLabel,
@@ -103,7 +104,7 @@ if _mkcc.tray is True:
             backend_options = constants.backend_options_for_platform(
                 _mkcc.platform
             )
-            self.backends: List[str] = []
+            self.backends: list[str] = []
             for option in backend_options:
                 if is_installed(option, PATH, _mkcc.debug):
                     self.backends.append(option)

--- a/mkchromecast/tray_threading.py
+++ b/mkchromecast/tray_threading.py
@@ -5,15 +5,17 @@ import os
 import socket
 
 import mkchromecast
+from mkchromecast import audio
+from mkchromecast import colors
+from mkchromecast import node
 from mkchromecast.audio_devices import inputdev, outputdev
 from mkchromecast.cast import Casting
 from mkchromecast.config import config_manager
-import mkchromecast.audio
-from mkchromecast.node import stream
+from mkchromecast.constatns import OpMode
 from mkchromecast.preferences import ConfigSectionMap
 from mkchromecast.pulseaudio import create_sink, check_sink
 from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot
-import mkchromecast.colors as colors
+
 
 # TODO(xsdg): Encapsulate this so that we don't do this work on import.
 _mkcc = mkchromecast.Mkchromecast()
@@ -48,7 +50,7 @@ class Worker(QObject):
         except OSError:
             self.cc.available_devices = []
 
-        if len(self.cc.available_devices) == 0 and _mkcc.tray is True:
+        if len(self.cc.available_devices) == 0 and _mkcc.operation == OpMode.TRAY:
             available_devices = []
             self.intReady.emit(available_devices)
             self.finished.emit()
@@ -77,7 +79,7 @@ class Player(QObject):
             backend = _mkcc.backend
         global cast
         if backend == "node":
-            stream()
+            node.stream_audio()
         else:
             try:
                 reload(mkchromecast.audio)

--- a/mkchromecast/utils.py
+++ b/mkchromecast/utils.py
@@ -14,8 +14,7 @@ from mkchromecast import constants
 from mkchromecast import messages
 
 
-def quantize_sample_rate(has_source_url: bool,
-                         codec: str,
+def quantize_sample_rate(codec: str,
                          sample_rate: int,
                          limit_to_48k: bool = False) -> int:
     """Takes an arbitrary sample rate and aligns it to a standard value.
@@ -24,8 +23,6 @@ def quantize_sample_rate(has_source_url: bool,
     a reasonable maximum for the specified codec.
 
     Args:
-        has_source_url: Whether mkcc.source_url is None.  Only used to avoid
-            printing a warning.
         codec: The name of the codec in use.
         sample_rate: The original sample rate.
 
@@ -76,15 +73,13 @@ def quantize_sample_rate(has_source_url: bool,
             # Because we're traversing in increasing order, the first time we
             # find a target_rate that's greater than the sample rate, we know
             # that's the next-largest value, so we can return that immediately.
-            if not has_source_url:
-                messages.print_samplerate_warning(codec)
+            messages.print_samplerate_warning(codec)
             return target_rate
 
     # If we make it to this point, sample_rate is above the max target_rate, so
     # we just clamp to the max target_rate.
-    if not has_source_url:
-        messages.print_samplerate_warning(codec)
-        print(colors.warning("Sample rate set to maximum!"))
+    messages.print_samplerate_warning(codec)
+    print(colors.warning("Sample rate set to maximum!"))
     return target_rates[-1]
 
 

--- a/mkchromecast/video.py
+++ b/mkchromecast/video.py
@@ -14,7 +14,7 @@ from mkchromecast import colors
 from mkchromecast import pipeline_builder
 from mkchromecast import stream_infra
 from mkchromecast import utils
-
+from mkchromecast.constants import OpMode
 
 def _flask_init():
     mkcc = mkchromecast.Mkchromecast()
@@ -27,6 +27,7 @@ def _flask_init():
         fps=mkcc.fps,
         input_file=mkcc.input_file,
         loop=mkcc.loop,
+        operation=mkcc.operation,
         resolution=mkcc.resolution,
         screencast=mkcc.screencast,
         seek=mkcc.seek,
@@ -57,6 +58,16 @@ def main():
         pipeline.start()
     else:
         print("Starting Node")
+
+        # TODO(xsdg): This implies that the `node` backend is only compatible
+        # with INPUT_FILE OpMode, for video.  Double-check what's happening here
+        # and then implement that constraint directly in the Mkchromecast class.
+        if mkcc.operation != OpMode.INPUT_FILE:
+            print(colors.warning(
+                "The node video backend requires and only supports the input "
+                "file operation (-i argument)."))
+            utils.terminate()
+
         if mkcc.platform == "Darwin":
             PATH = (
                 "./bin:./nodejs/bin:/Users/"
@@ -88,11 +99,6 @@ def main():
                         path = path + "html5-video-streamer.js"
                         webcast = [name, path, mkcc.input_file]
                         break
-
-        if mkcc.input_file == None:
-            print(colors.warning("Please specify an input file with -i"))
-            print(colors.warning("Closing the application..."))
-            utils.terminate()
 
         try:
             subprocess.Popen(webcast)

--- a/tests/test_instantiate.py
+++ b/tests/test_instantiate.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import mkchromecast
 from mkchromecast import _arg_parsing
+from mkchromecast import constants
 
 class BasicInstantiationTest(unittest.TestCase):
     def testInstantiate(self):
@@ -13,6 +14,8 @@ class BasicInstantiationTest(unittest.TestCase):
         mock_args = mock.Mock()
         # Here we set the minimal required args for __init__ to not sys.exit.
         mock_args.encoder_backend = None
+        mock_args.bitrate = constants.DEFAULT_BITRATE
+        mock_args.codec = 'mp3'
         mock_args.command = None
         mock_args.resolution = None
         mock_args.chunk_size = 64

--- a/tests/test_pipeline_builder.py
+++ b/tests/test_pipeline_builder.py
@@ -6,6 +6,7 @@ from unittest import mock
 from mkchromecast import pipeline_builder
 from mkchromecast import stream_infra
 from mkchromecast import utils
+from mkchromecast.constants import OpMode
 
 class AudioBuilderTests(unittest.TestCase):
 
@@ -314,7 +315,8 @@ class VideoBuilderTests(unittest.TestCase):
             "pipe:1",
         ]
 
-        builder = self.create_builder(input_file="input_file.mp4",
+        builder = self.create_builder(operation=OpMode.INPUT_FILE,
+                                      input_file="input_file.mp4",
                                       resolution="1080p")
         self.assertEqual(exp_command, builder.command)
 
@@ -332,7 +334,8 @@ class VideoBuilderTests(unittest.TestCase):
             "pipe:1",
         ]
 
-        builder = self.create_builder(input_file="input_file.mp4",
+        builder = self.create_builder(operation=OpMode.INPUT_FILE,
+                                      input_file="input_file.mp4",
                                       resolution=None,
                                       loop=True,
                                       seek="hh:mm:ss")


### PR DESCRIPTION
The goal is to reduce the number of places that need to test for different (and sometimes conflicting) operation mode flags, and to simplify and streamline the codepaths for each.