### PR TITLE
Drops remaining mentions of gstreamer.

### DIFF
--- a/mkchromecast/_arg_parsing.py
+++ b/mkchromecast/_arg_parsing.py
@@ -8,6 +8,7 @@ the command-line interface.
 import argparse
 import os
 
+from mkchromecast import constants
 from mkchromecast.resolution import resolutions
 
 
@@ -209,14 +210,13 @@ Parser.add_argument(
     "--encoder-backend",
     type=str,
     default=None,
-    choices=["ffmpeg", "gstreamer", "node", "parec"],
+    choices=constants.ALL_BACKENDS,
     help="""
     Set the backend for all encoders.
     Possible backends:
         - node (default in macOS)
         - parec (default in Linux)
         - ffmpeg
-        - gstreamer
 
     Example:
         python mkchromecast.py --encoder-backend ffmpeg

--- a/mkchromecast/constants.py
+++ b/mkchromecast/constants.py
@@ -34,7 +34,8 @@ def sample_rates_for_codec(codec: str) -> List[int]:
 
 DARWIN_BACKENDS = ["node", "ffmpeg"]
 LINUX_VIDEO_BACKENDS = ["node", "ffmpeg"]
-LINUX_BACKENDS = ["ffmpeg", "parec", "gstreamer"]
+LINUX_BACKENDS = ["ffmpeg", "parec"]
+ALL_BACKENDS = ["node", "ffmpeg", "parec"]
 
 def backend_options_for_platform(platform: str, video: bool = False):
     if platform == "Darwin":

--- a/mkchromecast/pipeline_builder.py
+++ b/mkchromecast/pipeline_builder.py
@@ -57,8 +57,7 @@ class Audio:
                 return self._build_linux_other_command()
 
             else:
-                # TODO(xsdg): gstreamer support never worked, so drop itDrop support for gstreamer.
-                raise Exception("gstreamer is not currently supported")
+                raise Exception(f"Unsupported backend: {self._backend.name}")
 
     def _input_command(self) -> list[str]:
         """Returns an appropriate set of input arguments for the pipeline.

--- a/mkchromecast/preferences.py
+++ b/mkchromecast/preferences.py
@@ -93,10 +93,6 @@ if _mkcc.operation == OpMode.TRAY:
             for option in backend_options:
                 if is_installed(option, PATH, _mkcc.debug):
                     backends.append(option)
-            # Hard-coded for gstreamer.
-            # if (_mkcc.platform == "Linux"
-            #     and is_installed("gst-launch-1.0", PATH, _mkcc.debug)):
-            #     self.backends.append("gstreamer")
 
             self.backend = QLabel("Select Backend", self)
             self.backend.move(20 * self.scale_factor, 24 * self.scale_factor)

--- a/mkchromecast/stream_infra.py
+++ b/mkchromecast/stream_infra.py
@@ -196,27 +196,6 @@ class FlaskServer:
                 message = "Have you installed lame, see https://github.com/muammar/mkchromecast#linux-1?"
                 raise Exception(message)
 
-        elif (
-            FlaskServer._platform == "Linux"
-            and FlaskServer._backend.name == "gstreamer"
-        ):
-            c_gst = [
-                "gst-launch-1.0",
-                "-v",
-                "!",
-                "audioconvert",
-                "!",
-                "filesink",
-                "location=/dev/stdout",
-            ]
-            if FlaskServer._adevice is not None:
-                c_gst.insert(2, "alsasrc")
-                c_gst.insert(3, 'device="' + FlaskServer._adevice + '"')
-            else:
-                c_gst.insert(2, "pulsesrc")
-                c_gst.insert(3, 'device="Mkchromecast.monitor"')
-            gst = Popen(c_gst, stdout=PIPE)
-            process = Popen(FlaskServer._command, stdin=gst.stdout, stdout=PIPE, bufsize=-1)
         else:
             process = Popen(FlaskServer._command, stdout=PIPE, bufsize=-1)
         read_chunk = partial(os.read, process.stdout.fileno(), FlaskServer._buffer_size)


### PR DESCRIPTION
This is mainly just cleanup, since the actual gstreamer support was in a non-functional and commented-out state and was mostly dropped in the pipeline_builder refactor.