### PR TITLE
Encode available device names to UTF-8

### DIFF
--- a/mkchromecast/cast.py
+++ b/mkchromecast/cast.py
@@ -59,7 +59,7 @@ def print_available_devices(devices: Iterable[AvailableDevice]):
     print(colors.important("Index   Type    Friendly Name "))
     print(colors.important("=====   =====   ============= "))
     for device in devices:
-        print(device)
+        print(f"{device.index} \t{device.type} \t{device.name.encode('utf-8').decode('utf-8')}")
 
 
 class Casting:


### PR DESCRIPTION
Resolves this error when attempting to run `bin/mkchromecast`.

```
Traceback (most recent call last):
  File "/home/<username>/mkchromecast/bin/mkchromecast", line 288, in <module>
    CastProcess(mkcc).run()
  File "/home/<username>/mkchromecast/bin/mkchromecast", line 68, in run
    self.start_audiocast()
  File "/home/<username>/mkchromecast/bin/mkchromecast", line 97, in start_audiocast
    self.cc.initialize_cast()
  File "/home/<username>/mkchromecast/bin/../mkchromecast/cast.py", line 114, in initialize_cast
    print_available_devices(self.available_devices)
  File "/home/<username>/mkchromecast/bin/../mkchromecast/cast.py", line 62, in print_available_devices
    print(device)
UnicodeEncodeError: 'latin-1' codec can't encode character '\u2019' in position 13: ordinal not in range(256)
Killed
```

For context, I am using the library on a Raspberry Pi 4 with the following system specifiations 

```
<username>@raspberrypi:~ $ cat /proc/version
Linux version 6.1.21-v8+ (dom@buildbot) (aarch64-linux-gnu-gcc-8 (Ubuntu/Linaro 8.4.0-3ubuntu1) 8.4.0, GNU ld (GNU Binutils for Ubuntu) 2.34) #1642 SMP PREEMPT Mon Apr  3 17:24:16 BST 2023
```

This solution works for me. However, I am not a Python developer, so please review this if there would be a better way to resolve this long term.