### PR TITLE
PR to issue: https://github.com/muammar/mkchromecast/issues/464

### DIFF
--- a/mkchromecast/tray_threading.py
+++ b/mkchromecast/tray_threading.py
@@ -58,7 +58,7 @@ class Player(QObject):
                 try:
                     reload(mkchromecast.audio)
                 except NameError:
-                    from imp import reload
+                    from importlib import reload
 
                     reload(mkchromecast.audio)
                 mkchromecast.audio.main()


### PR DESCRIPTION
# Scope
https://github.com/muammar/mkchromecast/issues/464

# What is changed
`mkchromecast/tray_threading.py` refers to `imp` that is no longer supported in python 3.12. This has been changed to `importlib`. Initial testing shows that it is working. 