### PR TITLE
Fixing missing assignment of MP3 Codec when specified, in conjucture with the Node backend

### DIFF
--- a/mkchromecast/__init__.py
+++ b/mkchromecast/__init__.py
@@ -145,7 +145,7 @@ class Mkchromecast:
             if args.codec != "mp3":
                 print(colors.warning(f"Setting codec from {args.codec} to mp3, "
                                      "as required by node backend"))
-                self.codec = "mp3"
+            self.codec = "mp3"
         else:  # not source_url and backend != "node"
             if args.codec not in codec_choices:
                 print(colors.options(f"Selected audio codec: {args.codec}."))

--- a/tests/test_instantiate.py
+++ b/tests/test_instantiate.py
@@ -25,6 +25,21 @@ class BasicInstantiationTest(unittest.TestCase):
         mock_args.input_file = None
         mkcc = mkchromecast.Mkchromecast(mock_args)
 
+    def testMP3CodecNodeBackend(self):
+        "This test evaluates the assignment of the MP3 codec when the Node Backend is selected"
+
+        mock_args = mock.Mock()
+        # Here we set the minimal required args for __init__ to not sys.exit.
+        mock_args.encoder_backend = 'node'
+        mock_args.bitrate = constants.DEFAULT_BITRATE
+        mock_args.codec = 'mp3'
+        mock_args.command = None
+        mock_args.resolution = None
+        mock_args.chunk_size = 64
+        mock_args.sample_rate = 44100
+        mock_args.youtube = None
+        mock_args.input_file = None
+        mkcc = mkchromecast.Mkchromecast(mock_args)
     def testTrayModeInstantiation(self):
         mock_config = mock.create_autospec(config.Config, spec_set=True)
         self.enterContext(mock.patch.object(config, "Config", return_value=mock_config))

--- a/tests/test_instantiate.py
+++ b/tests/test_instantiate.py
@@ -26,7 +26,7 @@ class BasicInstantiationTest(unittest.TestCase):
         mkcc = mkchromecast.Mkchromecast(mock_args)
 
     def testMP3CodecNodeBackend(self):
-        "This test evaluates the assignment of the MP3 codec when the Node Backend is selected"
+        """This test evaluates the assignment of the MP3 codec when the Node Backend is selected"""
 
         mock_args = mock.Mock()
         # Here we set the minimal required args for __init__ to not sys.exit.
@@ -40,6 +40,7 @@ class BasicInstantiationTest(unittest.TestCase):
         mock_args.youtube = None
         mock_args.input_file = None
         mkcc = mkchromecast.Mkchromecast(mock_args)
+
     def testTrayModeInstantiation(self):
         mock_config = mock.create_autospec(config.Config, spec_set=True)
         self.enterContext(mock.patch.object(config, "Config", return_value=mock_config))


### PR DESCRIPTION
**Scope**: There was an issue that the MP3 Codec was not assigned if it was assigned when using the Node Backend. If no codec, or any other codec was set, this would be set back to the MP3 codec. 

Related Issue: https://github.com/muammar/mkchromecast/issues/468 

**Work done**:
* The first commit covers a unit-test to replicate this issue. The error was reproducible by setting the backend to `Node` and the Codec to `MP3` as specified in the issue. 
* The second commit changes the indentation, assigning the MP3 codec in all cases of the `Node` backend. The print out is still specific to any other codec, explaining that it has been reset to MP3, as the node backend only supports MP3. 